### PR TITLE
Removed default value for json column

### DIFF
--- a/database/migrations/2025_02_07_190903_add_metadata_column_to_sources_table.php
+++ b/database/migrations/2025_02_07_190903_add_metadata_column_to_sources_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('sources', function (Blueprint $table) {
-            $table->json('metadata')->default('{}')->after('secret');
+            $table->json('metadata')->after('secret');
         });
     }
 


### PR DESCRIPTION
Mysql doesn't support default values for the json column.

<img width="850" alt="7fe05b2cb1dd7bf69afddeb334e61cc4" src="https://github.com/user-attachments/assets/2ab7aee2-f40d-4c53-b86a-577f4054074e" />
