### PR TITLE
Use zipball API to fetch ZIP archive when receiving webhook from GH

### DIFF
--- a/app/Sources/GitHub/Event/PushEvent.php
+++ b/app/Sources/GitHub/Event/PushEvent.php
@@ -30,7 +30,7 @@ class PushEvent extends Input implements Importable
 
     public function zipUrl(): string
     {
-        return "{$this->repository->htmlUrl}/archive/{$this->shortRef()}.zip";
+        return "{$this->repository->url}/zipball/{$this->ref}";
     }
 
     public function version(): string

--- a/tests/Feature/Incoming/PushTagTest.php
+++ b/tests/Feature/Incoming/PushTagTest.php
@@ -61,7 +61,7 @@ it('overwrites version for same tag', function (Repository $repository, SourcePr
 it('has correct zip url for tag', function (SourceProvider $provider, Importable $event, ...$rest): void {
     $url = match ($provider) {
         SourceProvider::GITEA => 'https://gitea.com/vendor/test/archive/v1.0.0.zip',
-        SourceProvider::GITHUB => 'https://github.com/vendor/test/archive/v1.0.0.zip',
+        SourceProvider::GITHUB => 'https://api.github.com/repos/vendor/test/zipball/refs/tags/v1.0.0',
         SourceProvider::GITLAB => 'https://gitlab.com/api/v4/projects/1/repository/archive.zip?sha=checkout-sha',
         SourceProvider::BITBUCKET => 'https://bitbucket.org/vendor/test/get/v1.0.0.zip',
     };
@@ -75,7 +75,7 @@ it('has correct zip url for tag', function (SourceProvider $provider, Importable
 it('has correct zip url for branch', function (SourceProvider $provider, Importable $event, ...$rest): void {
     $url = match ($provider) {
         SourceProvider::GITEA => 'https://gitea.com/vendor/test/archive/feature/my-feature.zip',
-        SourceProvider::GITHUB => 'https://github.com/vendor/test/archive/feature/my-feature.zip',
+        SourceProvider::GITHUB => 'https://api.github.com/repos/vendor/test/zipball/refs/heads/feature/my-feature',
         SourceProvider::GITLAB => 'https://gitlab.com/api/v4/projects/1/repository/archive.zip?sha=checkout-sha',
         SourceProvider::BITBUCKET => 'https://bitbucket.org/vendor/test/get/feature/my-feature.zip',
     };

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -358,7 +358,7 @@ function providerPushEvents(string $refType = 'tags', string $ref = '1.0.0'): ar
                     name: 'test',
                     fullName: 'vendor/test',
                     htmlUrl: 'https://github.com/vendor/test',
-                    url: 'https://github.com/vendor/test',
+                    url: 'https://api.github.com/repos/vendor/test',
                 )
             ),
             'archivePath' => __DIR__.'/Fixtures/gitea-jamie-test.zip',


### PR DESCRIPTION
I noticed that all `push` Github webhooks ended up with 422 error. The application was unable to fetch the contents of the ZIP archive.

After some digging, I noticed that the URL to ZIP archive is invalid. It uses the public url, which doesn't work with private packages. It should use the API url instead.