### PR TITLE
Use GH zipball API URL as `zipUrl` of branch input source

### DIFF
--- a/app/Sources/GitHub/GitHubClient.php
+++ b/app/Sources/GitHub/GitHubClient.php
@@ -66,7 +66,7 @@ class GitHubClient extends Client
             id: (string) $project->id,
             name: $item['name'],
             url: Normalizer::url($project->webUrl),
-            zipUrl: "$project->webUrl/archive/{$item['name']}.zip",
+            zipUrl: "{$project->url}/zipball/refs/heads/{$item['name']}",
         ), $data);
     }
 


### PR DESCRIPTION
Related with: #133 

Turns out I wasn't careful enough and didn't notice that the branch ZIP archives don't download as well. This PR resolves the issue.