### PR TITLE
Normalize versions with build id added after pre-release id

### DIFF
--- a/app/Normalizer.php
+++ b/app/Normalizer.php
@@ -42,8 +42,14 @@ class Normalizer
             return $version;
         }
 
-        if ((bool) preg_match('/^v?(\d+\.){1,3}\d+(-[a-zA-Z]+\d*)?$/', $version)) {
-            return trim($version, 'v');
+        $matches = [];
+
+        if ((bool) preg_match('/^v?(?<version>(\d+\.){1,3}\d+)(-(?<pre_release_id>[a-zA-Z0-9]+)\.?(?<build_id>\d*))?$/', $version, $matches)) {
+            return trim(vsprintf('%s-%s%s', [
+                $matches['version'],
+                $matches['pre_release_id'] ?? '',
+                $matches['build_id'] ?? '',
+            ]), '-');
         }
 
         throw new VersionNotFoundException;

--- a/tests/Unit/NormalizerTest.php
+++ b/tests/Unit/NormalizerTest.php
@@ -34,6 +34,8 @@ it('normalizes version', function (string $url, string $expected): void {
         'rc tag with v prefix' => ['v1.0.0-RC1', '1.0.0-RC1'],
         '4 version segments' => ['1.2.3.4', '1.2.3.4'],
         '4 version segments with v prefix' => ['v1.2.3.4', '1.2.3.4'],
+        'rc tag with a dot' => ['1.1.0-beta.2', '1.1.0-beta2'],
+        'rc tag with a dot and v prefix' => ['v1.1.0-beta.2', '1.1.0-beta2'],
     ]);
 
 it('fails to normalize unsupported versions', function (string $version): void {
@@ -55,4 +57,5 @@ it('converts version to sort order', function (string $version, string $expected
     ['3.0.0-RC10', '03.0000000.0000000.0000000-rc10'],
     ['3.0.0-RC', '03.0000000.0000000.0000000-rc00'],
     ['dev-foo', 'dev-foo'],
+    ['v1.1.0-beta.2', '01.0000001.0000000.0000000-beta02'],
 ]);


### PR DESCRIPTION
From specs (and some manual testing), the following versions are valid:

- `v1.0.0-beta.1`
- `v1.0.0-beta1`

Both of them are normalized to the same version: `1.0.0.0-beta1`.

The `Normalizer` failed to match versions which included the build id (`.1`) added after the pre-release id (`beta`).

I extended the regex pattern to include the dot which separates pre-release from build id.
For both versions, the Normalizer will generate the same output.

Related issues:
- #144 
- #130