### PR TITLE
Add rebuild package command and import batches UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-fpm-alpine AS base
+FROM php:8.4-alpine AS base
 
 LABEL org.opencontainers.image.source="https://github.com/packistry/packistry"
 LABEL org.opencontainers.image.description="Packistry is a Composer repository for PHP packages Packistry is a Composer repository for PHP packages"

--- a/app/Actions/Packages/RebuildPackage.php
+++ b/app/Actions/Packages/RebuildPackage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Packages;
+
+use App\Jobs\Batches\PackageImportBatch;
+use App\Models\Package;
+use RuntimeException;
+use Throwable;
+
+class RebuildPackage
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(Package $package): void
+    {
+        $source = $package->source;
+
+        if ($source === null || $package->provider_id === null) {
+            throw new RuntimeException("Package $package->name [$package->id] has no source or provider id");
+        }
+
+        $project = $source->client()->project($package->provider_id);
+
+        PackageImportBatch::make($source, $package, $project)
+            ->dispatch();
+    }
+}

--- a/app/Console/Commands/RebuildPackageCommand.php
+++ b/app/Console/Commands/RebuildPackageCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Actions\Packages\RebuildPackage;
+use App\Models\Package;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Throwable;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\multisearch;
+
+class RebuildPackageCommand extends Command
+{
+    protected $signature = 'rebuild:package';
+
+    protected $description = 'Rebuild package tags and branches';
+
+    public function handle(RebuildPackage $rebuildPackage): int
+    {
+        $packages = $this->packages(
+            all: confirm('Rebuild all packages?', false)
+        );
+
+        foreach ($packages as $package) {
+            try {
+                $rebuildPackage->handle($package);
+            } catch (Throwable $exception) {
+                $this->error($exception->getMessage());
+            }
+        }
+
+        $this->info("Rebuilding {$packages->count()} packages");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, Package>
+     */
+    private function packages(bool $all = false): Collection
+    {
+        return Package::query()
+            ->when(! $all, fn (Builder $query) => $query->whereIn('id', multisearch(
+                label: 'Select packages to rebuild',
+                options: fn (string $value) => Package::query()
+                    ->with('repository')
+                    ->when($value, fn (Builder $query) => $query->where('name', 'like', "$value%"))
+                    ->get()
+                    ->keyBy(fn (Package $package): string => (string) $package->id)
+                    ->map(fn (Package $package): string => "{$package->repository->name} > $package->name")
+                    ->toArray(),
+                required: true,
+            )))
+            ->with([
+                'source',
+            ])
+            ->get();
+    }
+}

--- a/app/Enums/Permission.php
+++ b/app/Enums/Permission.php
@@ -43,4 +43,7 @@ enum Permission: string
     case AUTHENTICATION_SOURCE_READ = 'authentication_source_read';
     case AUTHENTICATION_SOURCE_UPDATE = 'authentication_source_update';
     case AUTHENTICATION_SOURCE_DELETE = 'authentication_source_delete';
+
+    case BATCH_READ = 'batch_read';
+    case BATCH_DELETE = 'batch_delete';
 }

--- a/app/Http/Controllers/BatchController.php
+++ b/app/Http/Controllers/BatchController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\Permission;
+use App\Http\Resources\BatchResource;
+use Illuminate\Bus\BatchRepository;
+use Illuminate\Bus\DatabaseBatchRepository;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+readonly class BatchController extends Controller
+{
+    public function __construct(private BatchRepository $batches)
+    {
+        //
+    }
+
+    public function index(): AnonymousResourceCollection
+    {
+        $this->authorize(Permission::BATCH_READ);
+
+        $bathes = $this->batches->get(
+            limit: 1000,
+            before: null
+        );
+
+        return BatchResource::collection($bathes);
+    }
+
+    public function destroy(): void
+    {
+        $this->authorize(Permission::BATCH_DELETE);
+
+        if (! ($this->batches instanceof DatabaseBatchRepository)) {
+            return;
+        }
+
+        $this->batches->prune(
+            before: now()
+        );
+
+        $this->batches->pruneUnfinished(
+            before: now(),
+        );
+    }
+}

--- a/app/Http/Resources/BatchResource.php
+++ b/app/Http/Resources/BatchResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Bus\Batch;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Batch
+ */
+class BatchResource extends JsonResource
+{
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            $this->mergeWhen($this->options['package'] ?? false, fn () => [
+                'package' => new PackageResource($this->options['package']),
+            ]),
+            'total_jobs' => $this->totalJobs,
+            'pending_jobs' => $this->pendingJobs,
+            'processed_jobs' => $this->processedJobs(),
+            'progress' => $this->progress(),
+            'failed_jobs' => $this->failedJobs,
+            'created_at' => $this->createdAt,
+            'cancelled_at' => $this->cancelledAt,
+            'finished_at' => $this->finishedAt,
+        ];
+    }
+}

--- a/app/Jobs/Batches/PackageImportBatch.php
+++ b/app/Jobs/Batches/PackageImportBatch.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Batches;
+
+use App\Jobs\ImportBranches;
+use App\Jobs\ImportTags;
+use App\Models\Package;
+use App\Models\Source;
+use App\Sources\Project;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+
+class PackageImportBatch
+{
+    public static function make(
+        Source $source,
+        Package $package,
+        Project $project
+    ): PendingBatch {
+        return Bus::batch([
+            new ImportBranches($source, $package, $project),
+            new ImportTags($source, $package, $project),
+        ])
+            ->name(self::class)
+            ->withOption('package', $package)
+            ->allowFailures();
+    }
+}

--- a/frontend/src/api/batch.ts
+++ b/frontend/src/api/batch.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+import { del, get } from '@/api/axios'
+import { packageSchema } from '@/api/package'
+
+export const batch = z.object({
+    id: z.coerce.string(),
+    name: z.string(),
+    package: packageSchema.optional(),
+    totalJobs: z.number(),
+    failedJobs: z.number(),
+    pendingJobs: z.number(),
+    processedJobs: z.number(),
+    progress: z.number(),
+    createdAt: z.coerce.date(),
+    finishedAt: z.coerce.date().nullable(),
+    cancelledAt: z.coerce.date().nullable(),
+})
+
+export type Batch = z.infer<typeof batch>
+
+export function fetchBatches() {
+    return get(batch.array(), '/batches')
+}
+
+export function pruneBatches() {
+    return del(z.string(), '/batches')
+}

--- a/frontend/src/api/hooks.tsx
+++ b/frontend/src/api/hooks.tsx
@@ -44,6 +44,7 @@ import {
     storeAuthenticationSource,
     updateAuthenticationSource,
 } from '@/api/authentication-source'
+import { fetchBatches, pruneBatches } from '@/api/batch'
 
 const repositoriesKey = ['repositories']
 const packagesKey = ['packages']
@@ -51,6 +52,7 @@ const usersKey = ['users']
 const sourcesKey = ['sources']
 const deployTokenKey = ['deploy-tokens']
 const authenticationSourceKey = ['authentication-sources']
+const batchesKey = ['batches']
 const personalTokenKey = ['personal-tokens']
 
 export function useRepositories(query: RepositoryQuery) {
@@ -434,6 +436,28 @@ export function useDeleteAuthenticationSource() {
         onSuccess() {
             queryClient.invalidateQueries({
                 queryKey: authenticationSourceKey,
+                exact: false,
+            })
+        },
+    })
+}
+
+export function useBatches({ refetchInterval }: { refetchInterval?: number }) {
+    return useQuery({
+        queryFn: fetchBatches,
+        queryKey: [...batchesKey],
+        refetchInterval,
+    })
+}
+
+export function usePruneBatches() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: pruneBatches,
+        onSuccess() {
+            queryClient.invalidateQueries({
+                queryKey: [...batchesKey],
                 exact: false,
             })
         },

--- a/frontend/src/components/card/import-batch-card.tsx
+++ b/frontend/src/components/card/import-batch-card.tsx
@@ -1,0 +1,81 @@
+import { Card, CardContent } from '@/components/ui/card'
+import { CheckCircle2, CircleAlert, Loader2, Package } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
+import { Badge } from '@/components/ui/badge'
+import * as React from 'react'
+import { Batch } from '@/api/batch'
+import { formatDistance } from 'date-fns'
+
+export type ImportBatchCardProps = { batch: Batch }
+
+export function ImportBatchCard({ batch }: ImportBatchCardProps) {
+    let color = 'bg-gray-200'
+
+    if (batch.finishedAt !== null) {
+        color = 'bg-green-500'
+    }
+
+    if (batch.failedJobs > 0) {
+        color = 'bg-yellow-500'
+    }
+
+    const progress = ((batch.processedJobs + batch.failedJobs) / batch.totalJobs) * 100
+    const finished = batch.finishedAt !== null || batch.totalJobs - batch.failedJobs === batch.processedJobs
+
+    return (
+        <Card
+            key={batch.id}
+            className="overflow-hidden"
+        >
+            <div
+                className={`h-1 ${color}`}
+                style={{ width: `${progress}%` }}
+            />
+            <CardContent className="p-4">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        {finished ? (
+                            batch.failedJobs === 0 ? (
+                                <CheckCircle2 className="h-5 w-5 text-green-500" />
+                            ) : (
+                                <CircleAlert className="h-5 w-5 text-yellow-500" />
+                            )
+                        ) : (
+                            <Loader2 className="h-5 w-5 text-primary animate-spin" />
+                        )}
+                        <div className="flex items-center gap-2">
+                            <Package className="h-4 w-4 text-muted-foreground" />
+                            {batch.package ? (
+                                <Link
+                                    to="/packages/$packageId"
+                                    params={{ packageId: batch.package.id }}
+                                    className="font-medium"
+                                >
+                                    {batch.package.name}
+                                </Link>
+                            ) : (
+                                <span className="font-medium">Unknown</span>
+                            )}
+                            <span className="text-sm text-muted-foreground">
+                                Started {formatDistance(batch.createdAt, new Date(), { addSuffix: true })}
+                            </span>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <div className="flex items-center gap-2">
+                            <span className="text-sm text-right font-mediumz">
+                                {batch.processedJobs}/{batch.totalJobs}
+                            </span>
+                        </div>
+                        <Badge
+                            variant={finished ? 'default' : 'outline'}
+                            className="capitalize"
+                        >
+                            {finished ? 'Finished' : 'Pending'}
+                        </Badge>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -1,10 +1,20 @@
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { CodeIcon, DatabaseIcon, FingerprintIcon, HomeIcon, KeyIcon, PackageIcon, UsersIcon } from 'lucide-react'
+import {
+    CodeIcon,
+    DatabaseIcon,
+    DownloadIcon,
+    FingerprintIcon,
+    HomeIcon,
+    KeyIcon,
+    PackageIcon,
+    UsersIcon,
+} from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import React, { JSXElementConstructor } from 'react'
 import {
     AUTHENTICATION_SOURCE_READ,
+    BATCH_READ,
     DASHBOARD,
     DEPLOY_TOKEN_READ,
     PACKAGE_READ,
@@ -34,6 +44,12 @@ const navItems: NavItem[] = [
         href: '/authentication-sources',
         icon: FingerprintIcon,
         permission: AUTHENTICATION_SOURCE_READ,
+    },
+    {
+        name: 'Import Batches',
+        href: '/import-batches',
+        icon: DownloadIcon,
+        permission: BATCH_READ,
     },
 ]
 

--- a/frontend/src/permission.ts
+++ b/frontend/src/permission.ts
@@ -30,6 +30,8 @@ export const AUTHENTICATION_SOURCE_CREATE = 'authentication_source_create'
 export const AUTHENTICATION_SOURCE_READ = 'authentication_source_read'
 export const AUTHENTICATION_SOURCE_UPDATE = 'authentication_source_update'
 export const AUTHENTICATION_SOURCE_DELETE = 'authentication_source_delete'
+export const BATCH_READ = 'batch_read'
+export const BATCH_DELETE = 'batch_delete'
 
 export const permissions = [
     DASHBOARD,
@@ -62,6 +64,8 @@ export const permissions = [
     AUTHENTICATION_SOURCE_READ,
     AUTHENTICATION_SOURCE_UPDATE,
     AUTHENTICATION_SOURCE_DELETE,
+    BATCH_READ,
+    BATCH_DELETE,
 ] as const
 
 export const permission = z.enum(permissions)

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as AuthUsersImport } from './routes/_auth.users'
 import { Route as AuthSourcesImport } from './routes/_auth.sources'
 import { Route as AuthRepositoriesImport } from './routes/_auth.repositories'
 import { Route as AuthPersonalTokensImport } from './routes/_auth.personal-tokens'
+import { Route as AuthImportBatchesImport } from './routes/_auth.import-batches'
 import { Route as AuthDeployTokensImport } from './routes/_auth.deploy-tokens'
 import { Route as AuthAuthenticationSourcesImport } from './routes/_auth.authentication-sources'
 import { Route as AuthPackagesIndexImport } from './routes/_auth.packages.index'
@@ -26,277 +27,300 @@ import { Route as AuthPackagesPackageIdImport } from './routes/_auth.packages.$p
 // Create/Update Routes
 
 const LoginRoute = LoginImport.update({
-    id: '/login',
-    path: '/login',
-    getParentRoute: () => rootRoute,
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRoute,
 } as any)
 
 const AuthRoute = AuthImport.update({
-    id: '/_auth',
-    getParentRoute: () => rootRoute,
+  id: '/_auth',
+  getParentRoute: () => rootRoute,
 } as any)
 
 const AuthIndexRoute = AuthIndexImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthRoute,
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthUsersRoute = AuthUsersImport.update({
-    id: '/users',
-    path: '/users',
-    getParentRoute: () => AuthRoute,
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthSourcesRoute = AuthSourcesImport.update({
-    id: '/sources',
-    path: '/sources',
-    getParentRoute: () => AuthRoute,
+  id: '/sources',
+  path: '/sources',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthRepositoriesRoute = AuthRepositoriesImport.update({
-    id: '/repositories',
-    path: '/repositories',
-    getParentRoute: () => AuthRoute,
+  id: '/repositories',
+  path: '/repositories',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthPersonalTokensRoute = AuthPersonalTokensImport.update({
-    id: '/personal-tokens',
-    path: '/personal-tokens',
-    getParentRoute: () => AuthRoute,
+  id: '/personal-tokens',
+  path: '/personal-tokens',
+  getParentRoute: () => AuthRoute,
+} as any)
+
+const AuthImportBatchesRoute = AuthImportBatchesImport.update({
+  id: '/import-batches',
+  path: '/import-batches',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthDeployTokensRoute = AuthDeployTokensImport.update({
-    id: '/deploy-tokens',
-    path: '/deploy-tokens',
-    getParentRoute: () => AuthRoute,
+  id: '/deploy-tokens',
+  path: '/deploy-tokens',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthAuthenticationSourcesRoute = AuthAuthenticationSourcesImport.update({
-    id: '/authentication-sources',
-    path: '/authentication-sources',
-    getParentRoute: () => AuthRoute,
+  id: '/authentication-sources',
+  path: '/authentication-sources',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthPackagesIndexRoute = AuthPackagesIndexImport.update({
-    id: '/packages/',
-    path: '/packages/',
-    getParentRoute: () => AuthRoute,
+  id: '/packages/',
+  path: '/packages/',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthPackagesPackageIdRoute = AuthPackagesPackageIdImport.update({
-    id: '/packages/$packageId',
-    path: '/packages/$packageId',
-    getParentRoute: () => AuthRoute,
+  id: '/packages/$packageId',
+  path: '/packages/$packageId',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
-    interface FileRoutesByPath {
-        '/_auth': {
-            id: '/_auth'
-            path: ''
-            fullPath: ''
-            preLoaderRoute: typeof AuthImport
-            parentRoute: typeof rootRoute
-        }
-        '/login': {
-            id: '/login'
-            path: '/login'
-            fullPath: '/login'
-            preLoaderRoute: typeof LoginImport
-            parentRoute: typeof rootRoute
-        }
-        '/_auth/authentication-sources': {
-            id: '/_auth/authentication-sources'
-            path: '/authentication-sources'
-            fullPath: '/authentication-sources'
-            preLoaderRoute: typeof AuthAuthenticationSourcesImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/deploy-tokens': {
-            id: '/_auth/deploy-tokens'
-            path: '/deploy-tokens'
-            fullPath: '/deploy-tokens'
-            preLoaderRoute: typeof AuthDeployTokensImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/personal-tokens': {
-            id: '/_auth/personal-tokens'
-            path: '/personal-tokens'
-            fullPath: '/personal-tokens'
-            preLoaderRoute: typeof AuthPersonalTokensImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/repositories': {
-            id: '/_auth/repositories'
-            path: '/repositories'
-            fullPath: '/repositories'
-            preLoaderRoute: typeof AuthRepositoriesImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/sources': {
-            id: '/_auth/sources'
-            path: '/sources'
-            fullPath: '/sources'
-            preLoaderRoute: typeof AuthSourcesImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/users': {
-            id: '/_auth/users'
-            path: '/users'
-            fullPath: '/users'
-            preLoaderRoute: typeof AuthUsersImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/': {
-            id: '/_auth/'
-            path: '/'
-            fullPath: '/'
-            preLoaderRoute: typeof AuthIndexImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/packages/$packageId': {
-            id: '/_auth/packages/$packageId'
-            path: '/packages/$packageId'
-            fullPath: '/packages/$packageId'
-            preLoaderRoute: typeof AuthPackagesPackageIdImport
-            parentRoute: typeof AuthImport
-        }
-        '/_auth/packages/': {
-            id: '/_auth/packages/'
-            path: '/packages'
-            fullPath: '/packages'
-            preLoaderRoute: typeof AuthPackagesIndexImport
-            parentRoute: typeof AuthImport
-        }
+  interface FileRoutesByPath {
+    '/_auth': {
+      id: '/_auth'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof AuthImport
+      parentRoute: typeof rootRoute
     }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginImport
+      parentRoute: typeof rootRoute
+    }
+    '/_auth/authentication-sources': {
+      id: '/_auth/authentication-sources'
+      path: '/authentication-sources'
+      fullPath: '/authentication-sources'
+      preLoaderRoute: typeof AuthAuthenticationSourcesImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/deploy-tokens': {
+      id: '/_auth/deploy-tokens'
+      path: '/deploy-tokens'
+      fullPath: '/deploy-tokens'
+      preLoaderRoute: typeof AuthDeployTokensImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/import-batches': {
+      id: '/_auth/import-batches'
+      path: '/import-batches'
+      fullPath: '/import-batches'
+      preLoaderRoute: typeof AuthImportBatchesImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/personal-tokens': {
+      id: '/_auth/personal-tokens'
+      path: '/personal-tokens'
+      fullPath: '/personal-tokens'
+      preLoaderRoute: typeof AuthPersonalTokensImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/repositories': {
+      id: '/_auth/repositories'
+      path: '/repositories'
+      fullPath: '/repositories'
+      preLoaderRoute: typeof AuthRepositoriesImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/sources': {
+      id: '/_auth/sources'
+      path: '/sources'
+      fullPath: '/sources'
+      preLoaderRoute: typeof AuthSourcesImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/users': {
+      id: '/_auth/users'
+      path: '/users'
+      fullPath: '/users'
+      preLoaderRoute: typeof AuthUsersImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/': {
+      id: '/_auth/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof AuthIndexImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/packages/$packageId': {
+      id: '/_auth/packages/$packageId'
+      path: '/packages/$packageId'
+      fullPath: '/packages/$packageId'
+      preLoaderRoute: typeof AuthPackagesPackageIdImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/packages/': {
+      id: '/_auth/packages/'
+      path: '/packages'
+      fullPath: '/packages'
+      preLoaderRoute: typeof AuthPackagesIndexImport
+      parentRoute: typeof AuthImport
+    }
+  }
 }
 
 // Create and export the route tree
 
 interface AuthRouteChildren {
-    AuthAuthenticationSourcesRoute: typeof AuthAuthenticationSourcesRoute
-    AuthDeployTokensRoute: typeof AuthDeployTokensRoute
-    AuthPersonalTokensRoute: typeof AuthPersonalTokensRoute
-    AuthRepositoriesRoute: typeof AuthRepositoriesRoute
-    AuthSourcesRoute: typeof AuthSourcesRoute
-    AuthUsersRoute: typeof AuthUsersRoute
-    AuthIndexRoute: typeof AuthIndexRoute
-    AuthPackagesPackageIdRoute: typeof AuthPackagesPackageIdRoute
-    AuthPackagesIndexRoute: typeof AuthPackagesIndexRoute
+  AuthAuthenticationSourcesRoute: typeof AuthAuthenticationSourcesRoute
+  AuthDeployTokensRoute: typeof AuthDeployTokensRoute
+  AuthImportBatchesRoute: typeof AuthImportBatchesRoute
+  AuthPersonalTokensRoute: typeof AuthPersonalTokensRoute
+  AuthRepositoriesRoute: typeof AuthRepositoriesRoute
+  AuthSourcesRoute: typeof AuthSourcesRoute
+  AuthUsersRoute: typeof AuthUsersRoute
+  AuthIndexRoute: typeof AuthIndexRoute
+  AuthPackagesPackageIdRoute: typeof AuthPackagesPackageIdRoute
+  AuthPackagesIndexRoute: typeof AuthPackagesIndexRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
-    AuthAuthenticationSourcesRoute: AuthAuthenticationSourcesRoute,
-    AuthDeployTokensRoute: AuthDeployTokensRoute,
-    AuthPersonalTokensRoute: AuthPersonalTokensRoute,
-    AuthRepositoriesRoute: AuthRepositoriesRoute,
-    AuthSourcesRoute: AuthSourcesRoute,
-    AuthUsersRoute: AuthUsersRoute,
-    AuthIndexRoute: AuthIndexRoute,
-    AuthPackagesPackageIdRoute: AuthPackagesPackageIdRoute,
-    AuthPackagesIndexRoute: AuthPackagesIndexRoute,
+  AuthAuthenticationSourcesRoute: AuthAuthenticationSourcesRoute,
+  AuthDeployTokensRoute: AuthDeployTokensRoute,
+  AuthImportBatchesRoute: AuthImportBatchesRoute,
+  AuthPersonalTokensRoute: AuthPersonalTokensRoute,
+  AuthRepositoriesRoute: AuthRepositoriesRoute,
+  AuthSourcesRoute: AuthSourcesRoute,
+  AuthUsersRoute: AuthUsersRoute,
+  AuthIndexRoute: AuthIndexRoute,
+  AuthPackagesPackageIdRoute: AuthPackagesPackageIdRoute,
+  AuthPackagesIndexRoute: AuthPackagesIndexRoute,
 }
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
 
 export interface FileRoutesByFullPath {
-    '': typeof AuthRouteWithChildren
-    '/login': typeof LoginRoute
-    '/authentication-sources': typeof AuthAuthenticationSourcesRoute
-    '/deploy-tokens': typeof AuthDeployTokensRoute
-    '/personal-tokens': typeof AuthPersonalTokensRoute
-    '/repositories': typeof AuthRepositoriesRoute
-    '/sources': typeof AuthSourcesRoute
-    '/users': typeof AuthUsersRoute
-    '/': typeof AuthIndexRoute
-    '/packages/$packageId': typeof AuthPackagesPackageIdRoute
-    '/packages': typeof AuthPackagesIndexRoute
+  '': typeof AuthRouteWithChildren
+  '/login': typeof LoginRoute
+  '/authentication-sources': typeof AuthAuthenticationSourcesRoute
+  '/deploy-tokens': typeof AuthDeployTokensRoute
+  '/import-batches': typeof AuthImportBatchesRoute
+  '/personal-tokens': typeof AuthPersonalTokensRoute
+  '/repositories': typeof AuthRepositoriesRoute
+  '/sources': typeof AuthSourcesRoute
+  '/users': typeof AuthUsersRoute
+  '/': typeof AuthIndexRoute
+  '/packages/$packageId': typeof AuthPackagesPackageIdRoute
+  '/packages': typeof AuthPackagesIndexRoute
 }
 
 export interface FileRoutesByTo {
-    '/login': typeof LoginRoute
-    '/authentication-sources': typeof AuthAuthenticationSourcesRoute
-    '/deploy-tokens': typeof AuthDeployTokensRoute
-    '/personal-tokens': typeof AuthPersonalTokensRoute
-    '/repositories': typeof AuthRepositoriesRoute
-    '/sources': typeof AuthSourcesRoute
-    '/users': typeof AuthUsersRoute
-    '/': typeof AuthIndexRoute
-    '/packages/$packageId': typeof AuthPackagesPackageIdRoute
-    '/packages': typeof AuthPackagesIndexRoute
+  '/login': typeof LoginRoute
+  '/authentication-sources': typeof AuthAuthenticationSourcesRoute
+  '/deploy-tokens': typeof AuthDeployTokensRoute
+  '/import-batches': typeof AuthImportBatchesRoute
+  '/personal-tokens': typeof AuthPersonalTokensRoute
+  '/repositories': typeof AuthRepositoriesRoute
+  '/sources': typeof AuthSourcesRoute
+  '/users': typeof AuthUsersRoute
+  '/': typeof AuthIndexRoute
+  '/packages/$packageId': typeof AuthPackagesPackageIdRoute
+  '/packages': typeof AuthPackagesIndexRoute
 }
 
 export interface FileRoutesById {
-    __root__: typeof rootRoute
-    '/_auth': typeof AuthRouteWithChildren
-    '/login': typeof LoginRoute
-    '/_auth/authentication-sources': typeof AuthAuthenticationSourcesRoute
-    '/_auth/deploy-tokens': typeof AuthDeployTokensRoute
-    '/_auth/personal-tokens': typeof AuthPersonalTokensRoute
-    '/_auth/repositories': typeof AuthRepositoriesRoute
-    '/_auth/sources': typeof AuthSourcesRoute
-    '/_auth/users': typeof AuthUsersRoute
-    '/_auth/': typeof AuthIndexRoute
-    '/_auth/packages/$packageId': typeof AuthPackagesPackageIdRoute
-    '/_auth/packages/': typeof AuthPackagesIndexRoute
+  __root__: typeof rootRoute
+  '/_auth': typeof AuthRouteWithChildren
+  '/login': typeof LoginRoute
+  '/_auth/authentication-sources': typeof AuthAuthenticationSourcesRoute
+  '/_auth/deploy-tokens': typeof AuthDeployTokensRoute
+  '/_auth/import-batches': typeof AuthImportBatchesRoute
+  '/_auth/personal-tokens': typeof AuthPersonalTokensRoute
+  '/_auth/repositories': typeof AuthRepositoriesRoute
+  '/_auth/sources': typeof AuthSourcesRoute
+  '/_auth/users': typeof AuthUsersRoute
+  '/_auth/': typeof AuthIndexRoute
+  '/_auth/packages/$packageId': typeof AuthPackagesPackageIdRoute
+  '/_auth/packages/': typeof AuthPackagesIndexRoute
 }
 
 export interface FileRouteTypes {
-    fileRoutesByFullPath: FileRoutesByFullPath
-    fullPaths:
-        | ''
-        | '/login'
-        | '/authentication-sources'
-        | '/deploy-tokens'
-        | '/personal-tokens'
-        | '/repositories'
-        | '/sources'
-        | '/users'
-        | '/'
-        | '/packages/$packageId'
-        | '/packages'
-    fileRoutesByTo: FileRoutesByTo
-    to:
-        | '/login'
-        | '/authentication-sources'
-        | '/deploy-tokens'
-        | '/personal-tokens'
-        | '/repositories'
-        | '/sources'
-        | '/users'
-        | '/'
-        | '/packages/$packageId'
-        | '/packages'
-    id:
-        | '__root__'
-        | '/_auth'
-        | '/login'
-        | '/_auth/authentication-sources'
-        | '/_auth/deploy-tokens'
-        | '/_auth/personal-tokens'
-        | '/_auth/repositories'
-        | '/_auth/sources'
-        | '/_auth/users'
-        | '/_auth/'
-        | '/_auth/packages/$packageId'
-        | '/_auth/packages/'
-    fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | ''
+    | '/login'
+    | '/authentication-sources'
+    | '/deploy-tokens'
+    | '/import-batches'
+    | '/personal-tokens'
+    | '/repositories'
+    | '/sources'
+    | '/users'
+    | '/'
+    | '/packages/$packageId'
+    | '/packages'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/login'
+    | '/authentication-sources'
+    | '/deploy-tokens'
+    | '/import-batches'
+    | '/personal-tokens'
+    | '/repositories'
+    | '/sources'
+    | '/users'
+    | '/'
+    | '/packages/$packageId'
+    | '/packages'
+  id:
+    | '__root__'
+    | '/_auth'
+    | '/login'
+    | '/_auth/authentication-sources'
+    | '/_auth/deploy-tokens'
+    | '/_auth/import-batches'
+    | '/_auth/personal-tokens'
+    | '/_auth/repositories'
+    | '/_auth/sources'
+    | '/_auth/users'
+    | '/_auth/'
+    | '/_auth/packages/$packageId'
+    | '/_auth/packages/'
+  fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
-    AuthRoute: typeof AuthRouteWithChildren
-    LoginRoute: typeof LoginRoute
+  AuthRoute: typeof AuthRouteWithChildren
+  LoginRoute: typeof LoginRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
-    AuthRoute: AuthRouteWithChildren,
-    LoginRoute: LoginRoute,
+  AuthRoute: AuthRouteWithChildren,
+  LoginRoute: LoginRoute,
 }
 
-export const routeTree = rootRoute._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRoute
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
 /* ROUTE_MANIFEST_START
 {
@@ -313,6 +337,7 @@ export const routeTree = rootRoute._addFileChildren(rootRouteChildren)._addFileT
       "children": [
         "/_auth/authentication-sources",
         "/_auth/deploy-tokens",
+        "/_auth/import-batches",
         "/_auth/personal-tokens",
         "/_auth/repositories",
         "/_auth/sources",
@@ -331,6 +356,10 @@ export const routeTree = rootRoute._addFileChildren(rootRouteChildren)._addFileT
     },
     "/_auth/deploy-tokens": {
       "filePath": "_auth.deploy-tokens.tsx",
+      "parent": "/_auth"
+    },
+    "/_auth/import-batches": {
+      "filePath": "_auth.import-batches.tsx",
       "parent": "/_auth"
     },
     "/_auth/personal-tokens": {

--- a/frontend/src/routes/_auth.import-batches.tsx
+++ b/frontend/src/routes/_auth.import-batches.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useBatches, usePruneBatches } from '@/api/hooks'
+import { Heading } from '@/components/page/heading'
+import { Badge } from '@/components/ui/badge'
+import { Switch } from '@/components/ui/switch'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { z } from 'zod'
+import { ImportBatchCard } from '@/components/card/import-batch-card'
+import { Empty } from '@/components/empty'
+import { DownloadIcon } from 'lucide-react'
+
+export const Route = createFileRoute('/_auth/import-batches')({
+    validateSearch: z.object({
+        rate: z.number().min(100).optional().default(1000),
+        live: z.boolean().default(true),
+    }),
+    component: ImportBatchesComponent,
+})
+
+function ImportBatchesComponent() {
+    const { rate, live } = Route.useSearch()
+    const navigate = useNavigate()
+
+    const query = useBatches({ refetchInterval: live ? rate : undefined })
+    const mutation = usePruneBatches()
+    return (
+        <>
+            <Heading title="Import Batches">
+                <div className="flex items-center gap-3">
+                    <Button
+                        variant="outline"
+                        onClick={() => mutation.mutate()}
+                        dangerous={{
+                            title: 'Prune batches?',
+                            description: 'Are you sure you want to prune all existing batches?',
+                            confirm: {
+                                loading: mutation.isPending,
+                            },
+                        }}
+                    >
+                        Prune
+                    </Button>
+                    <span className="text-sm text-muted-foreground">Live updates:</span>
+                    <Switch
+                        checked={live}
+                        onCheckedChange={() => {
+                            navigate({
+                                to: '.',
+                                search: {
+                                    rate,
+                                    live: !live,
+                                },
+                            })
+                        }}
+                        aria-label="Toggle live updates"
+                    />
+
+                    {live ? (
+                        <div className="flex items-center gap-2">
+                            <span className="text-sm text-muted-foreground">Poll rate:</span>
+                            <Select
+                                value={rate.toString()}
+                                onValueChange={(value) =>
+                                    navigate({
+                                        to: '.',
+                                        search: {
+                                            rate: Number(value),
+                                            live,
+                                        },
+                                    })
+                                }
+                            >
+                                <SelectTrigger className="w-[130px] h-8">
+                                    <SelectValue placeholder="Select rate" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="1000">1 second</SelectItem>
+                                    <SelectItem value="3000">3 seconds</SelectItem>
+                                    <SelectItem value="5000">5 seconds</SelectItem>
+                                    <SelectItem value="10000">10 seconds</SelectItem>
+                                    <SelectItem value="30000">30 seconds</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    ) : (
+                        <Button
+                            loading={query.isRefetching}
+                            onClick={() => query.refetch()}
+                        >
+                            Refresh
+                        </Button>
+                    )}
+
+                    {live && (
+                        <Badge
+                            variant="outline"
+                            className="bg-green-500/10 text-green-500 border-green-500/20"
+                        >
+                            <span className="relative flex h-2 w-2 mr-1.5">
+                                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-500 opacity-75"></span>
+                                <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+                            </span>
+                            Live
+                        </Badge>
+                    )}
+                </div>
+            </Heading>
+            {query.data?.map((batch) => (
+                <ImportBatchCard
+                    key={batch.id}
+                    batch={batch}
+                />
+            ))}
+            {!query.isPending && query.data?.length === 0 && (
+                <Empty
+                    className="mt-24"
+                    title="No Import Batches"
+                    description="There are currently no packages being imported"
+                    icon={<DownloadIcon />}
+                />
+            )}
+        </>
+    )
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AuthenticationSourceController;
+use App\Http\Controllers\BatchController;
 use App\Http\Controllers\Composer;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DeployTokenController;
@@ -79,6 +80,9 @@ Route::middleware(['web', AcceptsJsonOrRedirectApp::class])->group(function (): 
         Route::post('/logout', [AuthController::class, 'logout']);
         Route::get('/me', [AuthController::class, 'show']);
         Route::patch('/me', [AuthController::class, 'update']);
+
+        Route::get('/batches', [BatchController::class, 'index']);
+        Route::delete('/batches', [BatchController::class, 'destroy']);
     });
 });
 

--- a/tests/Feature/Batch/IndexTest.php
+++ b/tests/Feature/Batch/IndexTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Enums\Permission;
+use App\Models\User;
+
+use function Pest\Laravel\getJson;
+
+it('indexes', function (?User $user, int $status): void {
+    getJson('/batches')
+        ->assertStatus($status);
+})->with(guestAndUsers(Permission::BATCH_READ));

--- a/tests/Feature/Batch/PruneTest.php
+++ b/tests/Feature/Batch/PruneTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Enums\Permission;
+use App\Models\User;
+
+use function Pest\Laravel\deleteJson;
+
+it('indexes', function (?User $user, int $status): void {
+    deleteJson('/batches')
+        ->assertStatus($status);
+})->with(guestAndUsers(Permission::BATCH_DELETE));


### PR DESCRIPTION
Closes #144, #130.

Introduces a new command `rebuild:package`. When running this command, the user will be asked if they want to rebuild all packages. If "no" is selected, specific packages can be chosen instead. It will then proceed to re-download all archives and create any missing versions.

Depending on the number of packages/versions you have, it might take some time to rebuild them all. To keep track of the progress, I added a new page `/import-batches`. This page also allows pruning previous import batches.

![Screenshot 2025-05-22 at 21 42 48](https://github.com/user-attachments/assets/77acad80-e539-4a7e-b209-506f960394e2)
