### PR TITLE
fix: use package name instead of provider id

### DIFF
--- a/app/Sources/Bitbucket/BitbucketClient.php
+++ b/app/Sources/Bitbucket/BitbucketClient.php
@@ -187,13 +187,12 @@ class BitbucketClient extends Client
     public function project(string $id): Project
     {
         $workspace = $this->workspace();
-        $url = "/2.0/repositories/$workspace";
+        $query = http_build_query(['q' => "uuid=\"$id\""]);
+        $url = "/2.0/repositories/{$workspace}?{$query}";
 
-        $id = Str::isUuid($id) ? '{'.$id.'}' : $id;
+        $response = $this->http()->get($url);
 
-        $response = $this->http()->get("$url/$id");
         $item = $response->json();
-
         $item = $item['values'][0] ?? $item;
 
         return new Project(

--- a/app/Sources/Bitbucket/BitbucketClient.php
+++ b/app/Sources/Bitbucket/BitbucketClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Sources\Bitbucket;
 
 use App\Exceptions\InvalidTokenException;
+use App\Models\Package;
 use App\Models\Repository;
 use App\Models\Source;
 use App\Sources\Branch;
@@ -180,9 +181,8 @@ class BitbucketClient extends Client
      */
     public function project(string $id): Project
     {
-        $workspace = $this->workspace();
-        $url = "/2.0/repositories/$workspace";
-        $response = $this->http()->get("$url/$id");
+        $package = Package::query()->where('provider_id', $id)->firstOrFail();
+        $response = $this->http()->get("/2.0/repositories/$package->name");
         $item = $response->json();
 
         if (! isset($item['slug'])) {

--- a/app/Sources/Bitbucket/BitbucketClient.php
+++ b/app/Sources/Bitbucket/BitbucketClient.php
@@ -17,7 +17,6 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Str;
 use RuntimeException;
 
 class BitbucketClient extends Client
@@ -78,7 +77,7 @@ class BitbucketClient extends Client
             }
 
             $projects = array_map(fn (array $item): Project => new Project(
-                id: $item['slug'],
+                id: trim($item['uuid'], '{}'),
                 fullName: $item['full_name'],
                 name: $item['name'],
                 url: $item['links']['self']['href'],
@@ -186,11 +185,11 @@ class BitbucketClient extends Client
      */
     public function project(string $id): Project
     {
-        $workspace = $this->workspace();
-        $query = http_build_query(['q' => "uuid=\"$id\""]);
-        $url = "/2.0/repositories/{$workspace}?{$query}";
+        $url = "/2.0/repositories/{$this->workspace()}";
 
-        $response = $this->http()->get($url);
+        $response = $this->http()->get($url, [
+            'q' => "uuid=\"$id\"",
+        ]);
 
         $item = $response->json();
         $item = $item['values'][0] ?? $item;


### PR DESCRIPTION
Bitbucket’s API supports repository lookup via either: ￼
	•	workspace UUID + repository ID
	•	package name ￼

However, combining these methods is not supported. The current implementation utilizes the workspace slug and provider ID, which does not yield valid responses from Bitbucket’s API. This approach fails to retrieve the desired package information.

To address this issue, i modified the integration to use the package name exclusively for repository lookup. This change eliminates the dependency on the workspace UUID, simplifying the process and ensuring compatibility with Bitbucket’s API.