### PR TITLE
fix: Use normalized version for zip creation to prevent UNIQUE constraint error

### DIFF
--- a/app/CreateFromZip.php
+++ b/app/CreateFromZip.php
@@ -58,7 +58,7 @@ class CreateFromZip
         }
 
         $createdVersion->package_id = $package->id;
-        $createdVersion->name = $version;
+        $createdVersion->name = Normalizer::version($version);
         $createdVersion->shasum = $hash;
         $createdVersion->metadata = collect($decoded)->only([
             'description',

--- a/database/migrations/2025_05_24_100934_normalize_package_versions.php
+++ b/database/migrations/2025_05_24_100934_normalize_package_versions.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Package;
+use App\Normalizer;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $packages = DB::table('packages')
+            ->join('versions', 'packages.id', '=', 'versions.package_id')
+            ->select('packages.id as package_id', 'versions.id as version_id', 'versions.name as version_name')
+            ->get();
+        
+        foreach ($packages as $package) {
+            try {
+                $normalizedVersion = Normalizer::version($package->version_name);
+                
+                if ($normalizedVersion !== $package->version_name) {
+
+                    $existingVersion = DB::table('versions')
+                        ->where('package_id', $package->package_id)
+                        ->where('name', $normalizedVersion)
+                        ->where('id', '!=', $package->version_id)
+                        ->first();
+                    
+                    if ($existingVersion) {
+
+                        DB::table('versions')
+                            ->where('id', $package->version_id)
+                            ->delete();
+                    } else {
+
+                        DB::table('versions')
+                            ->where('id', $package->version_id)
+                            ->update(['name' => $normalizedVersion]);
+                    }
+                }
+            } catch (\App\Exceptions\VersionNotFoundException $e) {
+                DB::table('failed_normalizations')->insert([
+                    'package_id' => $package->package_id,
+                    'version_id' => $package->version_id,
+                    'version_name' => $package->version_name,
+                    'error' => $e->getMessage(),
+                    'created_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // This migration cannot be reversed as it modifies data
+    }
+}; 

--- a/database/migrations/2025_05_24_100934_normalize_package_versions.php
+++ b/database/migrations/2025_05_24_100934_normalize_package_versions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -28,7 +30,7 @@ return new class extends Migration
                         ->where('id', '!=', $package->version_id)
                         ->first();
                     
-                    if ($existingVersion) {
+                    if ($existingVersion !== null) {
 
                         DB::table('versions')
                             ->where('id', $package->version_id)

--- a/database/migrations/2025_05_24_100934_normalize_package_versions.php
+++ b/database/migrations/2025_05_24_100934_normalize_package_versions.php
@@ -2,12 +2,9 @@
 
 declare(strict_types=1);
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use App\Models\Package;
 use App\Normalizer;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
@@ -17,11 +14,11 @@ return new class extends Migration
             ->join('versions', 'packages.id', '=', 'versions.package_id')
             ->select('packages.id as package_id', 'versions.id as version_id', 'versions.name as version_name')
             ->get();
-        
+
         foreach ($packages as $package) {
             try {
                 $normalizedVersion = Normalizer::version($package->version_name);
-                
+
                 if ($normalizedVersion !== $package->version_name) {
 
                     $existingVersion = DB::table('versions')
@@ -29,7 +26,7 @@ return new class extends Migration
                         ->where('name', $normalizedVersion)
                         ->where('id', '!=', $package->version_id)
                         ->first();
-                    
+
                     if ($existingVersion !== null) {
 
                         DB::table('versions')
@@ -58,4 +55,4 @@ return new class extends Migration
     {
         // This migration cannot be reversed as it modifies data
     }
-}; 
+};

--- a/database/migrations/2025_05_24_101047_create_failed_normalizations_table.php
+++ b/database/migrations/2025_05_24_101047_create_failed_normalizations_table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_05_24_101047_create_failed_normalizations_table.php
+++ b/database/migrations/2025_05_24_101047_create_failed_normalizations_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('failed_normalizations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('package_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('version_id')->constrained('versions')->cascadeOnDelete();
+            $table->string('version_name');
+            $table->text('error');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_normalizations');
+    }
+}; 

--- a/database/migrations/2025_05_24_101047_create_failed_normalizations_table.php
+++ b/database/migrations/2025_05_24_101047_create_failed_normalizations_table.php
@@ -24,4 +24,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('failed_normalizations');
     }
-}; 
+};


### PR DESCRIPTION
This PR sorts out an issue where creating zip files was failing for some older packages (those added before the version refactor). It was throwing an Integrity constraint violation: 19 UNIQUE constraint failed: versions.package_id, versions.name error.

The problem was that the zip creation wasn't using the normalized package version, leading to conflicts.