### PR TITLE
Add api prefix, add env vars for roadrunner config, add proxy ip parser.

### DIFF
--- a/.rr.production.yaml
+++ b/.rr.production.yaml
@@ -1,15 +1,26 @@
 version: '3'
 
 http:
-  address: 0.0.0.0:80
+  address: 0.0.0.0:${RR_PORT:-80}
   pool:
-    num_workers: 0
-    max_jobs: 0
+    num_workers: ${RR_NUM_WORKERS:-0}
+    max_jobs: ${RR_MAX_JOBS:-0}
     supervisor:
+      max_worker_memory: ${RR_MAX_WORKER_MEMORY:-128}
       exec_ttl: 30s
   static:
     dir: public
-  middleware: [ "static" ]
+  middleware: [ static, proxy_ip_parser, gzip ]
+  trusted_subnets:
+    [
+      "10.0.0.0/8",
+      "127.0.0.0/8",
+      "172.16.0.0/12",
+      "192.168.0.0/16",
+      "::1/128",
+      "fc00::/7",
+      "fe80::/10"
+    ]
 
 server:
   command: "php ./vendor/bin/roadrunner-worker"

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,9 +14,17 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
         apiPrefix: '',
         then: function (): void {
-            Route::middleware('web')
-                ->get('{any?}', fn () => response()->file(public_path('index.html')))->where('any', '.*');
-        },
+            Route::fallback(function () {
+                static $cachedIndex = null;
+
+                if ($cachedIndex === null) {
+                    $cachedIndex = file_get_contents(public_path('index.html'));
+                }
+
+                return response($cachedIndex, 200)
+                    ->header('Content-Type', 'text/html');
+            });
+        }
     )
     ->withMiddleware(function (Middleware $middleware): void {
         //

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -12,6 +12,7 @@ user=packistry
 numprocs=$WORKER_NUMPROCS
 redirect_stderr=true
 stdout_logfile=/var/www/html/worker.log
+stderr_logfile=/var/www/html/worker-error.log
 stopwaitsecs=3600
 
 [program:roadrunner]
@@ -20,4 +21,5 @@ command=rr serve -c .rr.production.yaml
 user=packistry
 autostart=true
 autorestart=true
-stdout_logfile=/var/www/html/worker.log
+stdout_logfile=/var/www/html/roadrunner.log
+stderr_logfile=/var/www/html/roadrunner-error.log

--- a/frontend/src/api/axios.tsx
+++ b/frontend/src/api/axios.tsx
@@ -13,7 +13,7 @@ import { UseQueryResult } from '@tanstack/react-query'
 axios.defaults.withCredentials = true
 axios.defaults.withXSRFToken = true
 
-export const baseURL = import.meta.env.DEV ? 'http://localhost' : ''
+export const baseURL = import.meta.env.DEV ? 'http://localhost/api' : '/api'
 axios.get(`${baseURL}/sanctum/csrf-cookie`)
 
 export const axiosDefaults: CreateAxiosDefaults = {

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,7 +15,6 @@ use App\Http\Controllers\SourceController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\VersionController;
 use App\Http\Controllers\Webhook;
-use App\Http\Middleware\AcceptsJsonOrRedirectApp;
 use App\Http\Middleware\ForceJson;
 
 if (! function_exists('repositoryRoutes')) {
@@ -39,14 +38,12 @@ if (! function_exists('repositoryRoutes')) {
     }
 }
 
-Route::middleware(['web'])->group(function (): void {
+Route::middleware('web')->prefix('/api')->group(function (): void {
+    Route::post('/login', [AuthController::class, 'login']);
+
     Route::get('/auths', [AuthController::class, 'sources']);
     Route::get('/auths/{authenticationSourceId}/redirect', [AuthController::class, 'redirect']);
     Route::get('/auths/{authenticationSourceId}/callback', [AuthController::class, 'callback']);
-});
-
-Route::middleware(['web', AcceptsJsonOrRedirectApp::class])->group(function (): void {
-    Route::post('/login', [AuthController::class, 'login']);
 
     Route::middleware('auth:sanctum')->group(function (): void {
         Route::get('/dashboard', DashboardController::class);
@@ -86,6 +83,12 @@ Route::middleware(['web', AcceptsJsonOrRedirectApp::class])->group(function (): 
         Route::get('/batches', [BatchController::class, 'index']);
         Route::delete('/batches', [BatchController::class, 'destroy']);
     });
+});
+
+// for backwards compatibility
+Route::middleware('web')->group(function (): void {
+    Route::get('/auths/{authenticationSourceId}/redirect', [AuthController::class, 'redirect']);
+    Route::get('/auths/{authenticationSourceId}/callback', [AuthController::class, 'callback']);
 });
 
 Route::prefix('/r/{repository}')->group(function (): void {

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -11,7 +11,7 @@ it('can authenticate with correct credentials', function () {
     $user = User::factory()
         ->create();
 
-    postJson('/login', ['email' => $user->email, 'password' => 'password'])
+    postJson('/api/login', ['email' => $user->email, 'password' => 'password'])
         ->assertOk();
 
     expect(auth()->check())->toBeTrue();
@@ -21,7 +21,7 @@ it('can not authenticate with incorrect credentials', function () {
     $user = User::factory()
         ->create();
 
-    postJson('/login', ['email' => $user->email, 'password' => 'incorrect'])
+    postJson('/api/login', ['email' => $user->email, 'password' => 'incorrect'])
         ->assertUnprocessable()
         ->assertExactJson(validation([
             'email' => ['The provided credentials are incorrect.'],
@@ -35,7 +35,7 @@ it('can not use local authentication with authentication source', function () {
         ->for(AuthenticationSource::factory())
         ->create();
 
-    postJson('/login', ['email' => $user->email, 'password' => 'password'])
+    postJson('/api/login', ['email' => $user->email, 'password' => 'password'])
         ->assertUnprocessable()
         ->assertExactJson(validation([
             'email' => ['The provided credentials are incorrect.'],

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -10,12 +10,12 @@ it('can logout', function () {
     $user = User::factory()
         ->create();
 
-    postJson('/login', ['email' => $user->email, 'password' => 'password'])
+    postJson('/api/login', ['email' => $user->email, 'password' => 'password'])
         ->assertOk();
 
     expect(auth()->guard('web')->check())->toBeTrue();
 
-    postJson('/logout')
+    postJson('/api/logout')
         ->assertNoContent();
 
     expect(auth()->guard('web')->check())->toBeFalse();

--- a/tests/Feature/Auth/ShowTest.php
+++ b/tests/Feature/Auth/ShowTest.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use function Pest\Laravel\getJson;
 
 it('shows authenticated user', function (?User $user, int $status) {
-    $response = getJson('/me')
+    $response = getJson('/api/me')
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/AuthenticationSources/DestroyTest.php
+++ b/tests/Feature/AuthenticationSources/DestroyTest.php
@@ -14,7 +14,7 @@ it('destroys', function (?User $user, int $status): void {
     $source = AuthenticationSource::factory()
         ->create();
 
-    $response = deleteJson("/authentication-sources/$source->id")
+    $response = deleteJson("/api/authentication-sources/$source->id")
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/AuthenticationSources/IndexTest.php
+++ b/tests/Feature/AuthenticationSources/IndexTest.php
@@ -14,7 +14,7 @@ it('indexes', function (?User $user, int $status): void {
 
     $sources->load('repositories');
 
-    $response = getJson('/authentication-sources')
+    $response = getJson('/api/authentication-sources')
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/AuthenticationSources/PublicIndexTest.php
+++ b/tests/Feature/AuthenticationSources/PublicIndexTest.php
@@ -12,7 +12,7 @@ it('shows public index', function (): void {
         ->count(5)
         ->create();
 
-    getJson('/auths')
+    getJson('/api/auths')
         ->assertStatus(200)
         ->assertExactJson(
             resourceAsJson(PublicAuthenticationSourceResource::collection($sources))

--- a/tests/Feature/AuthenticationSources/StoreTest.php
+++ b/tests/Feature/AuthenticationSources/StoreTest.php
@@ -29,7 +29,7 @@ it('stores', function (?User $user, int $status): void {
         ))->toArray()),
     ]);
 
-    $response = postJson('/authentication-sources', $attributes = [
+    $response = postJson('/api/authentication-sources', $attributes = [
         'name' => fake()->name,
         'provider' => AuthenticationProvider::OIDC,
         'client_id' => Str::random(),

--- a/tests/Feature/AuthenticationSources/UpdateTest.php
+++ b/tests/Feature/AuthenticationSources/UpdateTest.php
@@ -30,7 +30,7 @@ it('updates', function (?User $user, int $status): void {
         ))->toArray()),
     ]);
 
-    $response = patchJson("/authentication-sources/$source->id", $attributes = [
+    $response = patchJson("/api/authentication-sources/$source->id", $attributes = [
         'name' => fake()->name,
         'provider' => AuthenticationProvider::OIDC,
         'client_id' => Str::random(),

--- a/tests/Feature/Batch/IndexTest.php
+++ b/tests/Feature/Batch/IndexTest.php
@@ -6,6 +6,6 @@ use App\Models\User;
 use function Pest\Laravel\getJson;
 
 it('indexes', function (?User $user, int $status): void {
-    getJson('/batches')
+    getJson('/api/batches')
         ->assertStatus($status);
 })->with(guestAndUsers(Permission::BATCH_READ));

--- a/tests/Feature/Batch/PruneTest.php
+++ b/tests/Feature/Batch/PruneTest.php
@@ -6,6 +6,6 @@ use App\Models\User;
 use function Pest\Laravel\deleteJson;
 
 it('indexes', function (?User $user, int $status): void {
-    deleteJson('/batches')
+    deleteJson('/api/batches')
         ->assertStatus($status);
 })->with(guestAndUsers(Permission::BATCH_DELETE));

--- a/tests/Feature/Dashboard/DashboardTest.php
+++ b/tests/Feature/Dashboard/DashboardTest.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use function Pest\Laravel\getJson;
 
 it('shows dashboard', function (?User $user, int $status): void {
-    $response = getJson('/dashboard')
+    $response = getJson('/api/dashboard')
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/DeployToken/DestroyTest.php
+++ b/tests/Feature/DeployToken/DestroyTest.php
@@ -17,7 +17,7 @@ it('destroys', function (?User $user, int $status): void {
     /** @var DeployToken $token */
     $token = DeployToken::factory()->create();
 
-    deleteJson("/deploy-tokens/$token->id")
+    deleteJson("/api/deploy-tokens/$token->id")
         ->assertStatus($status);
 
     if ($status !== 201) {

--- a/tests/Feature/DeployToken/IndexTest.php
+++ b/tests/Feature/DeployToken/IndexTest.php
@@ -18,7 +18,7 @@ it('indexes', function (?User $user, int $status): void {
         );
     })->create();
 
-    $response = getJson('/deploy-tokens')
+    $response = getJson('/api/deploy-tokens')
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -44,11 +44,11 @@ it('searches', function (?User $user, int $status): void {
 
     $token->load('token');
 
-    getJson("/deploy-tokens?filter[search]=$token->name")
+    getJson("/api/deploy-tokens?filter[search]=$token->name")
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(DeployTokenResource::collection([$token])));
 
-    getJson('/deploy-tokens?filter[search]=something%20else')
+    getJson('/api/deploy-tokens?filter[search]=something%20else')
         ->assertStatus($status)
         ->assertJsonPath('data', []);
 })

--- a/tests/Feature/DeployToken/StoreTest.php
+++ b/tests/Feature/DeployToken/StoreTest.php
@@ -15,7 +15,7 @@ it('stores', function (?User $user, int $status): void {
     freezeSecond();
 
     Repository::factory()->create();
-    $response = postJson('/deploy-tokens', [
+    $response = postJson('/api/deploy-tokens', [
         'name' => $name = fake()->name,
         'abilities' => $abilities = [TokenAbility::REPOSITORY_READ->value],
         'expires_at' => $expiresAt = now()->addMonth()->format(DATE_RFC3339_EXTENDED),

--- a/tests/Feature/Package/DestroyTest.php
+++ b/tests/Feature/Package/DestroyTest.php
@@ -16,7 +16,7 @@ it('destroys', function (?User $user, int $status): void {
         ->for(Repository::factory())
         ->create();
 
-    $response = deleteJson("/packages/$package->id")
+    $response = deleteJson("/api/packages/$package->id")
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/Package/DownloadsTest.php
+++ b/tests/Feature/Package/DownloadsTest.php
@@ -16,7 +16,7 @@ it('shows package downloads', function (?User $user, int $status): void {
         ->has(Version::factory()->count(5))
         ->create();
 
-    $response = getJson('/packages/1/downloads')
+    $response = getJson('/api/packages/1/downloads')
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/Package/IndexTest.php
+++ b/tests/Feature/Package/IndexTest.php
@@ -24,7 +24,7 @@ it('shows index', function (?User $user, int $status): void {
     $packages = $query
         ->paginate(10);
 
-    $response = getJson('/packages')
+    $response = getJson('/api/packages')
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -50,15 +50,15 @@ it('searches', function (?User $user, int $status): void {
         ->for(Repository::factory())
         ->create();
 
-    getJson("/packages?filter[search]=$name")
+    getJson("/api/packages?filter[search]=$name")
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(PackageResource::collection([$package])));
 
-    getJson("/packages?filter[search]=$description")
+    getJson("/api/packages?filter[search]=$description")
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(PackageResource::collection([$package])));
 
-    getJson('/packages?filter[search]=something%20else')
+    getJson('/api/packages?filter[search]=something%20else')
         ->assertStatus($status)
         ->assertJsonPath('data', []);
 })
@@ -69,11 +69,11 @@ it('filters by repository id', function (?User $user, int $status): void {
         ->for(Repository::factory())
         ->create();
 
-    getJson('/packages?filter[repository_id]=1')
+    getJson('/api/packages?filter[repository_id]=1')
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(PackageResource::collection([$package])));
 
-    getJson('/packages?filter[repository_id]=2')
+    getJson('/api/packages?filter[repository_id]=2')
         ->assertStatus($status)
         ->assertJsonPath('data', []);
 })

--- a/tests/Feature/Package/ShowTest.php
+++ b/tests/Feature/Package/ShowTest.php
@@ -20,7 +20,7 @@ it('shows package', function (?User $user, int $status): void {
         ->has(Version::factory()->count(2))
         ->create();
 
-    $response = getJson("/packages/$package->id")
+    $response = getJson("/api/packages/$package->id")
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/Package/StoreTest.php
+++ b/tests/Feature/Package/StoreTest.php
@@ -76,7 +76,7 @@ it('stores', function (?User $user, int $status, SourceProvider $provider): void
         return $mock;
     });
 
-    postJson('/packages', [
+    postJson('/api/packages', [
         'repository' => (string) $repository->id,
         'source' => (string) $source->id,
         'projects' => [

--- a/tests/Feature/Package/VersionsTest.php
+++ b/tests/Feature/Package/VersionsTest.php
@@ -20,7 +20,7 @@ it('shows package versions', function (?User $user, int $status): void {
     $versions = Version::query()
         ->paginate(10);
 
-    $response = getJson('/packages/1/versions')
+    $response = getJson('/api/packages/1/versions')
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/PersonalToken/DestroyTest.php
+++ b/tests/Feature/PersonalToken/DestroyTest.php
@@ -15,7 +15,7 @@ it('destroys', function (?User $user, int $status): void {
 
     $token = $user->createToken('name');
 
-    deleteJson("/personal-tokens/{$token->accessToken->id}")
+    deleteJson("/api/personal-tokens/{$token->accessToken->id}")
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/PersonalToken/IndexTest.php
+++ b/tests/Feature/PersonalToken/IndexTest.php
@@ -17,7 +17,7 @@ it('indexes', function (?User $user, int $status): void {
     $user->createToken('name');
     $user->createToken('name 2');
 
-    $response = getJson('/personal-tokens')
+    $response = getJson('/api/personal-tokens')
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -39,11 +39,11 @@ it('searches', function (?User $user, int $status): void {
 
     $token = $user->createToken('name');
 
-    getJson('/personal-tokens?filter[search]=name')
+    getJson('/api/personal-tokens?filter[search]=name')
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(PersonalTokenResource::collection([$token->accessToken])));
 
-    getJson('/personal-tokens?filter[search]=something%20else')
+    getJson('/api/personal-tokens?filter[search]=something%20else')
         ->assertStatus($status)
         ->assertJsonPath('data', []);
 })

--- a/tests/Feature/PersonalToken/StoreTest.php
+++ b/tests/Feature/PersonalToken/StoreTest.php
@@ -16,7 +16,7 @@ it('stores', function (?User $user, int $status): void {
     freezeSecond();
 
     Repository::factory()->create();
-    $response = postJson('/personal-tokens', [
+    $response = postJson('/api/personal-tokens', [
         'name' => $name = fake()->name,
         'abilities' => $abilities = [TokenAbility::REPOSITORY_READ->value],
         'expires_at' => $expiresAt = now()->addMonth()->format(DATE_RFC3339_EXTENDED),

--- a/tests/Feature/Repository/DestroyTest.php
+++ b/tests/Feature/Repository/DestroyTest.php
@@ -13,7 +13,7 @@ use function Pest\Laravel\deleteJson;
 it('destroys', function (?User $user, int $status): void {
     $repository = Repository::factory()->create();
 
-    $response = deleteJson("/repositories/$repository->id")
+    $response = deleteJson("/api/repositories/$repository->id")
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/Repository/IndexTest.php
+++ b/tests/Feature/Repository/IndexTest.php
@@ -29,7 +29,7 @@ it('shows index', function (?User $user, int $status): void {
         ->withCount('packages')
         ->paginate(10);
 
-    $response = getJson('/repositories')
+    $response = getJson('/api/repositories')
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -56,15 +56,15 @@ it('searches', function (?User $user, int $status): void {
 
     $repository->loadCount('packages');
 
-    getJson("/repositories?filter[search]=$name")
+    getJson("/api/repositories?filter[search]=$name")
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(RepositoryResource::collection([$repository])));
 
-    getJson("/repositories?filter[search]=$description")
+    getJson("/api/repositories?filter[search]=$description")
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(RepositoryResource::collection([$repository])));
 
-    getJson('/repositories?filter[search]=something%20else')
+    getJson('/api/repositories?filter[search]=something%20else')
         ->assertStatus($status)
         ->assertJsonPath('data', []);
 })
@@ -79,11 +79,11 @@ it('filters by public', function (?User $user, int $status): void {
 
     $repository->loadCount('packages');
 
-    getJson('/repositories?filter[public]=true')
+    getJson('/api/repositories?filter[public]=true')
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(RepositoryResource::collection([$repository])));
 
-    getJson('/repositories?filter[public]=false')
+    getJson('/api/repositories?filter[public]=false')
         ->assertStatus($status)
         ->assertJsonPath('data', []);
 })

--- a/tests/Feature/Repository/StoreTest.php
+++ b/tests/Feature/Repository/StoreTest.php
@@ -12,7 +12,7 @@ use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\postJson;
 
 it('stores', function (?User $user, int $status): void {
-    $response = postJson('/repositories', $attributes = [
+    $response = postJson('/api/repositories', $attributes = [
         'name' => fake()->name,
         'path' => $path = fake()->sentence,
         'description' => fake()->text,
@@ -37,7 +37,7 @@ it('stores', function (?User $user, int $status): void {
 it('has unique path', function (?User $user, int $status): void {
     $repository = Repository::factory()->create();
 
-    postJson('/repositories', [
+    postJson('/api/repositories', [
         'name' => $repository->name,
         'path' => $repository->path,
     ])

--- a/tests/Feature/Repository/UpdateTest.php
+++ b/tests/Feature/Repository/UpdateTest.php
@@ -20,7 +20,7 @@ it('updates', function (?User $user, int $status): void {
         'public' => fake()->boolean(),
     ];
 
-    $response = patchJson("/repositories/$repository->id", $attributes)
+    $response = patchJson("/api/repositories/$repository->id", $attributes)
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -46,7 +46,7 @@ it('has unique path', function (?User $user, int $status): void {
         'path' => $otherRepository->path,
     ];
 
-    patchJson("/repositories/$repository->id", $attributes)
+    patchJson("/api/repositories/$repository->id", $attributes)
         ->assertStatus($status)
         ->assertExactJson(validation([
             'path' => ['Repository path has already been taken.'],

--- a/tests/Feature/Source/DestroyTest.php
+++ b/tests/Feature/Source/DestroyTest.php
@@ -13,7 +13,7 @@ use function Pest\Laravel\deleteJson;
 it('destroys', function (?User $user, int $status): void {
     $source = Source::factory()->create();
 
-    $response = deleteJson("/sources/$source->id")
+    $response = deleteJson("/api/sources/$source->id")
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/Source/IndexTest.php
+++ b/tests/Feature/Source/IndexTest.php
@@ -12,7 +12,7 @@ use function Pest\Laravel\getJson;
 it('indexes', function (?User $user, int $status): void {
     $sources = Source::factory()->count(10)->create();
 
-    $response = getJson('/sources')
+    $response = getJson('/api/sources')
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/Source/StoreTest.php
+++ b/tests/Feature/Source/StoreTest.php
@@ -26,7 +26,7 @@ it('stores', function (?User $user, int $status, SourceProvider $provider): void
         return $mock;
     });
 
-    $response = postJson('/sources', [
+    $response = postJson('/api/sources', [
         'name' => $name = fake()->name,
         'provider' => $provider,
         'url' => $url = fake()->url,

--- a/tests/Feature/Source/UpdateTest.php
+++ b/tests/Feature/Source/UpdateTest.php
@@ -27,7 +27,7 @@ it('updates', function (?User $user, int $status): void {
         return $mock;
     });
 
-    $response = patchJson("/sources/$source->id", [
+    $response = patchJson("/api/sources/$source->id", [
         'name' => $name = fake()->name,
         'url' => $url = fake()->url,
         'token' => $token = Str::random(),
@@ -60,7 +60,7 @@ it('does not update token when not given', function (?User $user, int $status): 
         ])
         ->create();
 
-    patchJson("/sources/$source->id", [
+    patchJson("/api/sources/$source->id", [
         'name' => $name = fake()->name,
         'url' => $url = fake()->url,
     ])

--- a/tests/Feature/User/DestroyTest.php
+++ b/tests/Feature/User/DestroyTest.php
@@ -12,7 +12,7 @@ use function Pest\Laravel\deleteJson;
 it('destroys', function (?User $user, int $status): void {
     $user = User::factory()->create();
 
-    $response = deleteJson("/users/$user->id")
+    $response = deleteJson("/api/users/$user->id")
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -28,7 +28,7 @@ it('destroys', function (?User $user, int $status): void {
     ->with(guestAndUsers(Permission::USER_DELETE));
 
 it('can not delete self', function (User $user, int $status): void {
-    deleteJson("/users/$user->id")
+    deleteJson("/api/users/$user->id")
         ->assertStatus($status);
 })
     ->with(unscopedUser(Permission::USER_DELETE, 403));

--- a/tests/Feature/User/IndexTest.php
+++ b/tests/Feature/User/IndexTest.php
@@ -11,7 +11,7 @@ use function Pest\Laravel\getJson;
 it('indexes', function (?User $user, int $status): void {
     User::factory()->count(8)->create();
 
-    $response = getJson('/users')
+    $response = getJson('/api/users')
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -37,15 +37,15 @@ it('searches', function (?User $user, int $status): void {
 
     $user->load('repositories', 'authenticationSource');
 
-    getJson("/users?filter[search]=$name")
+    getJson("/api/users?filter[search]=$name")
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(UserResource::collection([$user])));
 
-    getJson("/users?filter[search]=$email")
+    getJson("/api/users?filter[search]=$email")
         ->assertStatus($status)
         ->assertJsonPath('data', resourceAsJson(UserResource::collection([$user])));
 
-    getJson('/users?filter[search]=something%20else')
+    getJson('/api/users?filter[search]=something%20else')
         ->assertStatus($status)
         ->assertJsonPath('data', []);
 })

--- a/tests/Feature/User/StoreTest.php
+++ b/tests/Feature/User/StoreTest.php
@@ -13,7 +13,7 @@ use function Pest\Laravel\postJson;
 it('stores', function (?User $user, int $status, Role $role, array $repositories): void {
     Repository::factory()->create();
 
-    $response = postJson('/users', [
+    $response = postJson('/api/users', [
         'name' => $name = fake()->name,
         'email' => $email = fake()->unique()->email,
         'role' => $role,
@@ -56,7 +56,7 @@ it('stores', function (?User $user, int $status, Role $role, array $repositories
 it('has unique email', function (?User $user, int $status): void {
     $user = User::factory()->create();
 
-    postJson('/users', [
+    postJson('/api/users', [
         'name' => fake()->name,
         'email' => $user->email,
         'role' => Role::USER,
@@ -71,7 +71,7 @@ it('has unique email', function (?User $user, int $status): void {
     ->with(unscopedUser(Permission::USER_CREATE, expectedStatus: 422));
 
 it('requires valid email', function (?User $user, int $status): void {
-    postJson('/users', [
+    postJson('/api/users', [
         'name' => fake()->name,
         'email' => fake()->name,
         'role' => Role::USER,

--- a/tests/Feature/User/UpdateMeTest.php
+++ b/tests/Feature/User/UpdateMeTest.php
@@ -26,7 +26,7 @@ it('updates', function (?User $user, int $status): void {
         ],
     ];
 
-    $response = patchJson('/me', $attributes)
+    $response = patchJson('/api/me', $attributes)
         ->assertStatus($status);
 
     if ($status !== 200) {

--- a/tests/Feature/User/UpdateTest.php
+++ b/tests/Feature/User/UpdateTest.php
@@ -27,7 +27,7 @@ it('updates', function (?User $user, int $status): void {
         'repositories' => [],
     ];
 
-    $response = patchJson("/users/$user->id", $attributes)
+    $response = patchJson("/api/users/$user->id", $attributes)
         ->assertStatus($status);
 
     if ($status !== 200) {
@@ -59,7 +59,7 @@ it('has unique email', function (?User $user, int $status): void {
         'email' => $otherUser->email,
     ];
 
-    patchJson("/users/$user->id", $attributes)
+    patchJson("/api/users/$user->id", $attributes)
         ->assertStatus($status)
         ->assertExactJson(validation([
             'email' => ['Email has already been taken.'],


### PR DESCRIPTION
The frontend and backend share some routes, and depending on the content type, the correct one should serve. This probably causes issues where the frontend response gets cached by the browser and then used as a cache for the API request. This PR adds an `/api` prefix to the routes used by the web UI to address that.

Routes used by Composer are unchanged. If you built anything against the undocumented API, you will need to add the `/api` prefix there too when upgrading.

This PR also introduces a few new env variables to configure RoadRunner:

| Mame                    | Default | Description               |
| ----------------------- | ------- | ------------------------- |
| RR_PORT                | 80      | Port RoadRunner starts on |
| RR_NUM_WORKERS        | 0       | Number of workers         |
| RR_MAX_WORKER_MEMORY | 128     | Maximum memory per worker |

Possibly fixes #209