### PR TITLE
fix: change shasum column type from char to string

### DIFF
--- a/database/migrations/2024_09_21_121192_create_versions_table.php
+++ b/database/migrations/2024_09_21_121192_create_versions_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->foreignId('package_id')->constrained()->cascadeOnDelete();
             $table->string('name');
             $table->json('metadata');
-            $table->char('shasum', 64);
+            $table->string('shasum', 64);
 
             $table->string('order')->index();
             $table->timestamps();


### PR DESCRIPTION
Change the shasum column type in the versions table migration from char(64) to string (varchar).

Problem
PostgreSQL's CHAR(n) type pads values with trailing spaces up to the defined length. SHA-1 hashes are 40 characters long, so a CHAR(64) column produces values like:

(24 trailing spaces)

This causes integrity/checksum verification to fail because the stored value no longer matches the computed hash.

Why this only affects PostgreSQL
MySQL silently trims trailing spaces from CHAR columns on read, so the padding is never visible to the application. PostgreSQL does not trim on read — it returns the full padded value, which is the correct behavior per the SQL standard. Since Packistry originally targeted MySQL, this was never an issue until PostgreSQL was used as the database backend.

Fix
Replace the char(64) column definition with string (Laravel's VARCHAR(255)) in the migration. This stores only the actual hash characters without any padding, making the behavior consistent across both MySQL and PostgreSQL.

Migration note
Existing deployments on PostgreSQL need to trim the already-padded values:

This happens automatically when the migration runs the column type change, as PostgreSQL trims on cast from CHAR to VARCHAR.