### PR TITLE
feat: add repository sync modes and manual ZIP package upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packistry
 
-Packistry is a self-hosted Composer repository designed to handle your PHP package distribution. It supports importing from multiple sources like GitHub, GitLab, Gitea and Bitbucket, with seamless updates using webhooks. Packistry allows you to effortlessly run your own composer repository with just a few commands, giving you full control over your packages, access management, and security.
+Packistry is a self-hosted Composer repository designed to handle your PHP package distribution. It supports importing from multiple sources like GitHub, GitLab, Gitea and Bitbucket, with seamless updates using webhooks. Packistry also supports fully manual package management via ZIP uploads (no source sync required). Packistry allows you to effortlessly run your own composer repository with just a few commands, giving you full control over your packages, access management, and security.
 
 - Explore the docs at **[https://packistry.github.io/ »](https://packistry.github.io/)**
 
@@ -17,6 +17,8 @@ Packistry is a self-hosted Composer repository designed to handle your PHP packa
     - **Bitbucket**
 
   Stays up to date automatically, as Packistry uses **webhooks** to pull the latest changes from your source.
+
+- **Manual ZIP Uploads (No Sync Required)**: Upload package ZIP files directly when you do not want to configure a source provider or webhook sync.
 
 - **Comprehensive Repository Management**:
     - **Public/Private Repository Options**: Define repositories as public or private based on your project needs.
@@ -86,4 +88,3 @@ Please review [our security policy](./SECURITY.md) on how to report security vul
 ## License
 
 Packistry is open-sourced software licensed under the [GPL-3.0](./LICENSE).
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packistry
 
-Packistry is a self-hosted Composer repository designed to handle your PHP package distribution. It supports importing from multiple sources like GitHub, GitLab, Gitea and Bitbucket, with seamless updates using webhooks. Packistry also supports fully manual package management via ZIP uploads (no source sync required). Packistry allows you to effortlessly run your own composer repository with just a few commands, giving you full control over your packages, access management, and security.
+Packistry is a self-hosted Composer repository designed to handle your PHP package distribution. It supports importing from multiple sources like GitHub, GitLab, Gitea and Bitbucket, with seamless updates using webhooks, as well as fully manual package management through ZIP uploads. With just a few commands, you can run your own Composer repository while maintaining full control over your packages, access management, and security.
 
 - Explore the docs at **[https://packistry.github.io/ »](https://packistry.github.io/)**
 

--- a/app/Actions/Packages/Exceptions/RepositoryDoesNotSupportSourceSync.php
+++ b/app/Actions/Packages/Exceptions/RepositoryDoesNotSupportSourceSync.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Packages\Exceptions;
+
+use App\HasValidationMessage;
+use Illuminate\Validation\ValidationException;
+use RuntimeException;
+
+class RepositoryDoesNotSupportSourceSync extends RuntimeException implements HasValidationMessage
+{
+    public function asValidationMessage(string $attribute = 'repository'): ValidationException
+    {
+        return ValidationException::withMessages([
+            $attribute => 'Source import is disabled for this repository. Use manual ZIP upload instead.',
+        ]);
+    }
+}

--- a/app/Actions/Packages/Inputs/UploadPackageZipInput.php
+++ b/app/Actions/Packages/Inputs/UploadPackageZipInput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Packages\Inputs;
+
+use App\Actions\Input;
+
+class UploadPackageZipInput extends Input
+{
+    public function __construct(
+        public string $repository,
+        public string $filePath,
+        public ?string $version = null,
+    ) {
+        //
+    }
+}

--- a/app/Actions/Packages/StorePackage.php
+++ b/app/Actions/Packages/StorePackage.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Packages;
 
+use App\Actions\Packages\Exceptions\RepositoryDoesNotSupportSourceSync;
 use App\Actions\Packages\Inputs\StorePackageInput;
 use App\Enums\PackageType;
+use App\Enums\RepositorySyncMode;
 use App\Exceptions\ArchiveInvalidContentTypeException;
 use App\Exceptions\ComposerJsonNotFoundException;
 use App\Exceptions\FailedToFetchArchiveException;
@@ -40,6 +42,10 @@ class StorePackage
     {
         /** @var Repository $repository */
         $repository = Repository::query()->findOrFail($input->repository);
+
+        if ($repository->sync_mode === RepositorySyncMode::MANUAL) {
+            throw new RepositoryDoesNotSupportSourceSync;
+        }
 
         /** @var Source $source */
         $source = Source::query()->findOrFail($input->source);

--- a/app/Actions/Packages/UploadPackageZip.php
+++ b/app/Actions/Packages/UploadPackageZip.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Packages;
+
+use App\Actions\Packages\Inputs\UploadPackageZipInput;
+use App\CreateFromZip;
+use App\Enums\PackageType;
+use App\Exceptions\NameNotFoundException;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Version;
+use App\Traits\ComposerFromZip;
+
+class UploadPackageZip
+{
+    use ComposerFromZip;
+
+    public function __construct(private readonly CreateFromZip $createFromZip) {}
+
+    public function handle(UploadPackageZipInput $input): Version
+    {
+        /** @var Repository $repository */
+        $repository = Repository::query()->findOrFail($input->repository);
+
+        $decoded = $this->decodedComposerJsonFromZip($input->filePath);
+        $packageName = $decoded['name'] ?? throw new NameNotFoundException('no name provided');
+
+        /** @var Package|null $package */
+        $package = $repository
+            ->packages()
+            ->where('name', $packageName)
+            ->first();
+
+        if ($package === null) {
+            $package = new Package;
+            $package->repository_id = $repository->id;
+            $package->type = PackageType::LIBRARY->value;
+            $package->name = $packageName;
+            $package->save();
+        }
+
+        return $this->createFromZip->create(
+            package: $package,
+            path: $input->filePath,
+            version: $input->version,
+        );
+    }
+}

--- a/app/Actions/Repositories/Inputs/StoreRepositoryInput.php
+++ b/app/Actions/Repositories/Inputs/StoreRepositoryInput.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Repositories\Inputs;
 
 use App\Actions\Input;
+use App\Enums\RepositorySyncMode;
 
 class StoreRepositoryInput extends Input
 {
@@ -13,6 +14,7 @@ class StoreRepositoryInput extends Input
         public ?string $path = null,
         public ?string $description = null,
         public bool $public = false,
+        public RepositorySyncMode $syncMode = RepositorySyncMode::SOURCE,
     ) {
         //
     }

--- a/app/Actions/Repositories/Inputs/UpdateRepositoryInput.php
+++ b/app/Actions/Repositories/Inputs/UpdateRepositoryInput.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Repositories\Inputs;
 
 use App\Actions\Input;
+use App\Enums\RepositorySyncMode;
 
 class UpdateRepositoryInput extends Input
 {
@@ -13,6 +14,7 @@ class UpdateRepositoryInput extends Input
         public ?string $path,
         public ?string $description = null,
         public bool $public = false,
+        public RepositorySyncMode $syncMode = RepositorySyncMode::SOURCE,
     ) {
         //
     }

--- a/app/Actions/Repositories/StoreRepository.php
+++ b/app/Actions/Repositories/StoreRepository.php
@@ -26,6 +26,7 @@ class StoreRepository
 
         $repository->description = $input->description;
         $repository->public = $input->public;
+        $repository->sync_mode = $input->syncMode;
 
         $repository->save();
 

--- a/app/Actions/Repositories/UpdateRepository.php
+++ b/app/Actions/Repositories/UpdateRepository.php
@@ -24,6 +24,7 @@ class UpdateRepository
 
         $repository->description = $input->description;
         $repository->public = $input->public;
+        $repository->sync_mode = $input->syncMode;
 
         $repository->save();
 

--- a/app/Enums/RepositorySyncMode.php
+++ b/app/Enums/RepositorySyncMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum RepositorySyncMode: string
+{
+    case SOURCE = 'source';
+    case MANUAL = 'manual';
+}

--- a/app/Http/Controllers/PackageController.php
+++ b/app/Http/Controllers/PackageController.php
@@ -6,17 +6,22 @@ namespace App\Http\Controllers;
 
 use App\Actions\Packages\DestroyPackage;
 use App\Actions\Packages\Inputs\StorePackageInput;
+use App\Actions\Packages\Inputs\UploadPackageZipInput;
 use App\Actions\Packages\RebuildPackage;
 use App\Actions\Packages\StorePackage;
+use App\Actions\Packages\UploadPackageZip;
 use App\Enums\Permission;
 use App\Http\Resources\PackageResource;
+use App\Http\Resources\VersionResource;
 use App\Models\Builders\RepositoryBuilder;
 use App\Models\Download;
 use App\Models\Package;
+use App\Models\Repository;
 use App\SearchFilter;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 use Throwable;
@@ -27,6 +32,7 @@ readonly class PackageController extends Controller
         private StorePackage $storePackage,
         private DestroyPackage $destroyPackage,
         private RebuildPackage $rebuildPackage,
+        private UploadPackageZip $uploadPackageZip,
     ) {
         //
     }
@@ -130,6 +136,36 @@ readonly class PackageController extends Controller
 
         return response()->json(
             new PackageResource($package)
+        );
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function upload(Request $request, string $repositoryId): JsonResponse
+    {
+        $this->authorize(Permission::PACKAGE_CREATE);
+
+        $request->validate([
+            'file' => ['required', 'file', 'mimes:zip'],
+            'version' => ['nullable', 'string'],
+        ]);
+
+        /** @var Repository $repository */
+        $repository = Repository::query()->findOrFail($repositoryId);
+
+        /** @var UploadedFile $file */
+        $file = $request->file('file');
+
+        $version = $this->uploadPackageZip->handle(new UploadPackageZipInput(
+            repository: (string) $repository->id,
+            filePath: (string) $file->getRealPath(),
+            version: $request->string('version')->toString() ?: null,
+        ));
+
+        return response()->json(
+            new VersionResource($version),
+            201,
         );
     }
 }

--- a/app/Http/Resources/RepositoryResource.php
+++ b/app/Http/Resources/RepositoryResource.php
@@ -28,6 +28,7 @@ class RepositoryResource extends JsonResource
             'path' => $this->path,
             'description' => $this->description,
             'public' => $this->public,
+            'sync_mode' => $this->sync_mode,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
             'url' => $this->url(),

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\RepositorySyncMode;
 use App\Models\Builders\RepositoryBuilder;
 use Database\Factories\RepositoryFactory;
 use Eloquent;
@@ -22,6 +23,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $path
  * @property string|null $description
  * @property bool $public
+ * @property RepositorySyncMode $sync_mode
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Collection<int, Package> $packages
@@ -41,6 +43,7 @@ class Repository extends Model
 
     protected $casts = [
         'public' => 'bool',
+        'sync_mode' => RepositorySyncMode::class,
     ];
 
     /**

--- a/app/Traits/ComposerFromZip.php
+++ b/app/Traits/ComposerFromZip.php
@@ -24,9 +24,7 @@ trait ComposerFromZip
         }
 
         try {
-            $directory = $this->directoryFromArchive($zip);
-
-            $index = $zip->locateName($directory.'composer.json');
+            $index = $this->composerJsonIndexFromArchive($zip);
 
             if ($index === false) {
                 return throw new ComposerJsonNotFoundException('composer.json not found in archive');
@@ -50,19 +48,42 @@ trait ComposerFromZip
         }
     }
 
-    /**
-     * @throws FailedToOpenArchiveException
-     */
-    private function directoryFromArchive(ZipArchive $zip): string
+    private function composerJsonIndexFromArchive(ZipArchive $zip): int|false
     {
-        $directory = $zip->getNameIndex(0);
+        $rootIndex = $zip->locateName('composer.json');
 
-        if ($directory === false) {
-            throw new FailedToOpenArchiveException('failed to determine directory name');
+        if ($rootIndex !== false) {
+            return $rootIndex;
         }
 
-        return str_ends_with($directory, '/')
-            ? $directory
-            : '';
+        $topLevelDirectory = null;
+
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $entry = $zip->getNameIndex($i);
+
+            if ($entry === false) {
+                continue;
+            }
+
+            $entry = ltrim($entry, '/');
+
+            if ($entry === '' || str_starts_with($entry, '__MACOSX/')) {
+                continue;
+            }
+
+            $topLevel = explode('/', $entry)[0];
+
+            if ($topLevelDirectory === null) {
+                $topLevelDirectory = $topLevel;
+            } elseif ($topLevelDirectory !== $topLevel) {
+                return false;
+            }
+        }
+
+        if ($topLevelDirectory === null) {
+            return false;
+        }
+
+        return $zip->locateName($topLevelDirectory.'/composer.json');
     }
 }

--- a/database/factories/RepositoryFactory.php
+++ b/database/factories/RepositoryFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Enums\RepositorySyncMode;
 use App\Models\Package;
 use App\Models\Repository;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -26,6 +27,7 @@ class RepositoryFactory extends Factory
             'name' => fake()->name(),
             'path' => Str::slug(fake()->name()),
             'public' => false,
+            'sync_mode' => RepositorySyncMode::SOURCE,
         ];
     }
 

--- a/database/migrations/2026_03_12_120000_add_sync_mode_column_to_repositories_table.php
+++ b/database/migrations/2026_03_12_120000_add_sync_mode_column_to_repositories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\RepositorySyncMode;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('repositories', function (Blueprint $table): void {
+            $table->string('sync_mode')
+                ->default(RepositorySyncMode::SOURCE->value)
+                ->after('public')
+                ->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('repositories', function (Blueprint $table): void {
+            $table->dropColumn('sync_mode');
+        });
+    }
+};

--- a/frontend/src/api/repository.ts
+++ b/frontend/src/api/repository.ts
@@ -2,12 +2,16 @@ import { z } from 'zod'
 import { del, get, patch, post } from '@/api/axios'
 import { paginated, paginatedQuery, toQueryString } from '@/api/pagination'
 
+export const repositorySyncMode = z.enum(['source', 'manual'])
+export type RepositorySyncMode = z.infer<typeof repositorySyncMode>
+
 export const repository = z.object({
     id: z.coerce.string(),
     name: z.string(),
     path: z.string().nullable(),
     description: z.string().nullable(),
     public: z.boolean(),
+    syncMode: repositorySyncMode,
     url: z.string(),
     packagesCount: z.number().optional(),
     createdAt: z.coerce.date(),
@@ -37,6 +41,7 @@ export const storeRepositoryInput = z.object({
     path: z.string(),
     description: z.string(),
     public: z.boolean(),
+    syncMode: repositorySyncMode,
 })
 
 export type StoreRepositoryInput = z.infer<typeof storeRepositoryInput>
@@ -51,6 +56,7 @@ export const updateRepositoryInput = z.object({
     path: z.string(),
     description: z.string(),
     public: z.boolean(),
+    syncMode: repositorySyncMode,
 })
 
 export type UpdateRepositoryInput = z.infer<typeof updateRepositoryInput>

--- a/frontend/src/components/badge/repository-badge.tsx
+++ b/frontend/src/components/badge/repository-badge.tsx
@@ -2,8 +2,11 @@ import { Badge } from '@/components/ui/badge'
 import * as React from 'react'
 import { Repository } from '@/api'
 
-export function RepositoryBadge({ repository }: { repository: Pick<Repository, 'public'> }) {
+export function RepositoryBadge({ repository }: { repository: Pick<Repository, 'public' | 'syncMode'> }) {
     return (
-        <Badge variant={repository.public ? 'default' : 'secondary'}>{repository.public ? 'Public' : 'Private'}</Badge>
+        <div className="flex items-center gap-2">
+            <Badge variant={repository.public ? 'default' : 'secondary'}>{repository.public ? 'Public' : 'Private'}</Badge>
+            {repository.syncMode === 'manual' && <Badge variant="outline">Manual ZIP</Badge>}
+        </div>
     )
 }

--- a/frontend/src/components/dialog/add-package-dialog.tsx
+++ b/frontend/src/components/dialog/add-package-dialog.tsx
@@ -7,13 +7,16 @@ import { FormSourceSelect } from '@/components/form/elements/form-source-select'
 import { FormSourceProjectCheckboxGroup } from '@/components/form/elements/form-source-project-checkbox-group'
 import { FormSwitch } from '@/components/form/elements/form-switch'
 import { Form } from '@/components/ui/form'
-import { useStorePackage } from '@/api/hooks'
+import { useRepositories, useStorePackage } from '@/api/hooks'
 import { useForm } from '@/hooks/useForm'
 import { toast } from 'sonner'
 import { useInnerDialog } from '@/components/dialog/use-search-dialog'
 import { useAuth } from '@/auth'
 import { PACKAGE_CREATE } from '@/permission'
 import { DialogProps } from '@radix-ui/react-dialog'
+import { isValidationError } from '@/api'
+import { addValidationToForm } from '@/hooks/useForm'
+import { api } from '@/api/axios'
 
 export type AddPackageDialogProps = DialogProps
 export function AddPackageDialog(props: AddPackageDialogProps) {
@@ -38,6 +41,70 @@ export function AddPackageDialog(props: AddPackageDialogProps) {
     })
 
     const source = form.watch('source')
+    const repositoryId = form.watch('repository')
+    const repositories = useRepositories({
+        size: 1000,
+    })
+
+    const repository = repositories.data?.data.find((item) => item.id === repositoryId)
+    const isManualRepository = repository?.syncMode === 'manual'
+    const uploadInputRef = React.useRef<HTMLInputElement>(null)
+
+    const [isUploadPending, setIsUploadPending] = React.useState(false)
+    const [uploadError, setUploadError] = React.useState<string | null>(null)
+
+    const onUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0]
+
+        setUploadError(null)
+
+        if (!file || !repositoryId) {
+            return
+        }
+
+        setIsUploadPending(true)
+
+        try {
+            const data = new FormData()
+
+            data.append('file', file)
+
+            await api.post(`/repositories/${repositoryId}/uploads`, data, {
+                headers: {
+                    Accept: 'application/json',
+                },
+                transformRequest: [(rawData) => rawData],
+            })
+
+            toast('ZIP uploaded successfully')
+            form.reset()
+            dialogProps.onOpenChange?.(false)
+        } catch (error) {
+            if (isValidationError(error)) {
+                addValidationToForm(form, error)
+
+                const errors = error.response?.data?.errors
+                const message = errors?.repository?.[0] ?? errors?.repository ?? errors?.file?.[0] ?? errors?.file
+
+                if (message) {
+                    setUploadError(String(message))
+                    toast.error(String(message))
+                }
+
+                return
+            }
+
+            setUploadError('ZIP upload failed. Please try again.')
+            toast.error('ZIP upload failed. Please try again.')
+        } finally {
+            setIsUploadPending(false)
+            event.target.value = ''
+        }
+    }
+
+    const onSelectUpload = () => {
+        uploadInputRef.current?.click()
+    }
 
     return (
         <Dialog {...dialogProps}>
@@ -55,18 +122,45 @@ export function AddPackageDialog(props: AddPackageDialogProps) {
                 </DialogHeader>
                 <Form {...form}>
                     <form
-                        onSubmit={onSubmit}
+                        onSubmit={isManualRepository ? (event) => event.preventDefault() : onSubmit}
                         className="space-y-4"
                     >
                         <FormRepositorySelect
                             description="Select the repository where this package will be added."
                             control={form.control}
                         />
-                        <FormSourceSelect
-                            description="Choose the source from which to add a package."
-                            control={form.control}
-                        />
-                        {source && (
+                        {!isManualRepository && (
+                            <FormSourceSelect
+                                description="Choose the source from which to add a package."
+                                control={form.control}
+                            />
+                        )}
+                        {isManualRepository && (
+                            <>
+                                <div className="space-y-2">
+                                    <label className="text-sm font-medium">ZIP Archive</label>
+                                    <p className="text-sm text-muted-foreground">
+                                        Upload a ZIP archive containing composer.json. The package name is read automatically.
+                                    </p>
+                                    <input
+                                        ref={uploadInputRef}
+                                        type="file"
+                                        accept=".zip,application/zip"
+                                        className="hidden"
+                                        onChange={onUpload}
+                                    />
+                                    <Button
+                                        type="button"
+                                        loading={isUploadPending}
+                                        onClick={onSelectUpload}
+                                    >
+                                        Select ZIP and Upload
+                                    </Button>
+                                    {uploadError && <p className="text-sm font-medium text-destructive">{uploadError}</p>}
+                                </div>
+                            </>
+                        )}
+                        {!isManualRepository && source && (
                             <>
                                 <FormSourceProjectCheckboxGroup
                                     source={source}
@@ -81,12 +175,14 @@ export function AddPackageDialog(props: AddPackageDialogProps) {
                                 />
                             </>
                         )}
-                        <Button
-                            type="submit"
-                            loading={isPending}
-                        >
-                            Add package
-                        </Button>
+                        {!isManualRepository && (
+                            <Button
+                                type="submit"
+                                loading={isPending}
+                            >
+                                Add package
+                            </Button>
+                        )}
                     </form>
                 </Form>
             </DialogContent>

--- a/frontend/src/components/dialog/add-repository-dialog.tsx
+++ b/frontend/src/components/dialog/add-repository-dialog.tsx
@@ -23,6 +23,7 @@ export function AddRepositoryDialog(props: DialogProps) {
             path: '',
             description: '',
             public: false,
+            syncMode: 'source',
         },
         onSuccess() {
             form.reset()

--- a/frontend/src/components/dialog/edit-repository-dialog.tsx
+++ b/frontend/src/components/dialog/edit-repository-dialog.tsx
@@ -26,6 +26,7 @@ export function EditRepositoryDialog({ repository, trigger }: EditRepositoryDial
             // @todo meh
             path: repository.path ? repository.path : '',
             description: repository.description ? repository.description : '',
+            syncMode: repository.syncMode,
         },
         onSuccess() {
             setIsDialogOpen(false)

--- a/frontend/src/components/dropdown-menu/package-actions-dropdown-menu.tsx
+++ b/frontend/src/components/dropdown-menu/package-actions-dropdown-menu.tsx
@@ -8,7 +8,7 @@ import { useRebuildPackage } from '@/api/hooks'
 import { ConfirmDialog } from '@/components/dialog/confirm-dialog'
 
 export type PackageActionsDropdownMenuProps = {
-    pkg?: Pick<Package, 'id' | 'name'>
+    pkg?: Pick<Package, 'id' | 'name' | 'source'>
 }
 
 export function PackageActionsDropdownMenu({ pkg }: PackageActionsDropdownMenuProps) {
@@ -50,7 +50,7 @@ export function PackageActionsDropdownMenu({ pkg }: PackageActionsDropdownMenuPr
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                     <DropdownMenuItem
-                        disabled={!pkg}
+                        disabled={!pkg || pkg.source === null}
                         onClick={() => setShowConfirm(true)}
                     >
                         <RefreshCw className="mr-2 h-4 w-4" />

--- a/frontend/src/components/form/elements/form-repository-select.tsx
+++ b/frontend/src/components/form/elements/form-repository-select.tsx
@@ -36,7 +36,7 @@ export function FormRepositorySelect(props: Omit<Optional<FormSelectProps, 'name
             }}
             options={(query.data?.data || []).map((repository) => ({
                 value: repository.id,
-                label: repository.name,
+                label: repository.syncMode === 'manual' ? `${repository.name} (Manual ZIP)` : repository.name,
             }))}
         />
     )

--- a/frontend/src/components/form/repository-form-elements.tsx
+++ b/frontend/src/components/form/repository-form-elements.tsx
@@ -1,4 +1,5 @@
 import { FormInput } from '@/components/form/elements/form-input'
+import { FormSelect } from '@/components/form/elements/form-select'
 import { FormSwitch } from '@/components/form/elements/form-switch'
 import * as React from 'react'
 import { UseFormReturn } from 'react-hook-form'
@@ -34,6 +35,16 @@ export function RepositoryFormElements({
                 description="If the repository is public, any one can download its packages without needing authentication."
                 name="public"
                 control={form.control}
+            />
+            <FormSelect
+                name="syncMode"
+                label="Synchronization"
+                description="Choose how packages are maintained in this repository."
+                control={form.control}
+                options={[
+                    { value: 'source', label: 'Source Sync' },
+                    { value: 'manual', label: 'Manual ZIP (No Sync)' },
+                ]}
             />
         </>
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -68,6 +68,8 @@ Route::middleware('web')->prefix('/api')->group(function (): void {
         Route::apiResource('/packages', PackageController::class)
             ->only(['index', 'store', 'destroy', 'show']);
 
+        Route::post('/repositories/{repositoryId}/uploads', [PackageController::class, 'upload']);
+
         Route::post('/packages/{packageId}/rebuild', [PackageController::class, 'rebuild']);
 
         Route::apiResource('/packages/{packageId}/versions', VersionController::class)

--- a/tests/Feature/Package/StoreTest.php
+++ b/tests/Feature/Package/StoreTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\PackageType;
 use App\Enums\Permission;
+use App\Enums\RepositorySyncMode;
 use App\Enums\SourceProvider;
 use App\Import;
 use App\Models\Package;
@@ -162,3 +163,24 @@ it('stores', function (?User $user, int $status, SourceProvider $provider): void
 })
     ->with(guestAndUsers(Permission::PACKAGE_CREATE, userWithPermission: 201))
     ->with(SourceProvider::cases());
+
+it('rejects source sync import for manual repository', function (): void {
+    $repository = Repository::factory()->state([
+        'sync_mode' => RepositorySyncMode::MANUAL,
+    ])->create();
+
+    $source = Source::factory()->create();
+
+    user([Permission::UNSCOPED, Permission::PACKAGE_CREATE]);
+
+    postJson('/api/packages', [
+        'repository' => (string) $repository->id,
+        'source' => (string) $source->id,
+        'projects' => ['1'],
+        'webhook' => false,
+    ])
+        ->assertStatus(422)
+        ->assertExactJson(validation([
+            'repository' => ['Source import is disabled for this repository. Use manual ZIP upload instead.'],
+        ]));
+});

--- a/tests/Feature/Package/UploadTest.php
+++ b/tests/Feature/Package/UploadTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Permission;
+use App\Enums\RepositorySyncMode;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\Version;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\post;
+
+$composerJson = json_encode([
+    'name' => 'test/test',
+    'description' => 'description',
+    'version' => '1.0.0',
+    'autoload' => [
+        'psr-4' => [
+            'Test\\Test\\' => 'src/',
+        ],
+    ],
+    'authors' => [
+        [
+            'name' => 'Test Test',
+            'email' => 'test@test.test',
+        ],
+    ],
+    'require' => new stdClass,
+], JSON_THROW_ON_ERROR);
+
+$zipContent = static function (array $entries): string {
+    $temporary = tempnam(sys_get_temp_dir(), 'packistry-upload-test-');
+
+    if ($temporary === false) {
+        throw new RuntimeException('failed to create temporary file for ZIP fixture');
+    }
+
+    $path = $temporary.'.zip';
+
+    if (! rename($temporary, $path)) {
+        @unlink($temporary);
+
+        throw new RuntimeException('failed to prepare temporary ZIP path');
+    }
+
+    $zip = new ZipArchive;
+
+    try {
+        if ($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new RuntimeException('failed to open temporary ZIP archive');
+        }
+
+        foreach ($entries as $name => $content) {
+            if (str_ends_with($name, '/')) {
+                $zip->addEmptyDir(rtrim($name, '/'));
+
+                continue;
+            }
+
+            $zip->addFromString($name, $content);
+        }
+
+        $zip->close();
+
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            throw new RuntimeException('failed to read temporary ZIP archive');
+        }
+
+        return $content;
+    } finally {
+        @unlink($path);
+    }
+};
+
+it('uploads zip for repository and creates package', function (?User $user, int $status): void {
+    Storage::fake();
+
+    $repository = Repository::factory()->state([
+        'sync_mode' => RepositorySyncMode::MANUAL,
+        'name' => 'test/test',
+    ])->create();
+
+    $file = UploadedFile::fake()->createWithContent(
+        name: 'project.zip',
+        content: (string) file_get_contents(__DIR__.'/../../Fixtures/project.zip')
+    );
+
+    $response = post(
+        "/api/repositories/$repository->id/uploads",
+        [
+            'file' => $file,
+        ],
+        [
+            'Accept' => 'application/json',
+        ],
+    )->assertStatus($status);
+
+    if ($status !== 201) {
+        return;
+    }
+
+    /** @var Package $package */
+    $package = Package::query()->firstOrFail();
+    /** @var Version $version */
+    $version = Version::query()->firstOrFail();
+
+    $response->assertJsonPath('package_id', $package->id);
+    $response->assertJsonPath('name', '1.0.0');
+
+    expect($package->name)->toBe('test/test');
+    Storage::disk()->assertExists($version->archive_path, $file->getContent());
+})->with(guestAndUsers(Permission::PACKAGE_CREATE, userWithPermission: 201));
+
+it('validates upload payload', function (): void {
+    user([Permission::UNSCOPED, Permission::PACKAGE_CREATE]);
+
+    $repository = Repository::factory()->create();
+
+    post(
+        "/api/repositories/$repository->id/uploads",
+        [
+            'file' => UploadedFile::fake()->create('archive.txt', 10, 'text/plain'),
+        ],
+        [
+            'Accept' => 'application/json',
+        ],
+    )
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['file']);
+});
+
+it('allows upload for source sync repository', function (): void {
+    user([Permission::UNSCOPED, Permission::PACKAGE_CREATE]);
+
+    Storage::fake();
+
+    $repository = Repository::factory()->create();
+
+    $file = UploadedFile::fake()->createWithContent(
+        name: 'project.zip',
+        content: (string) file_get_contents(__DIR__.'/../../Fixtures/project.zip')
+    );
+
+    post(
+        "/api/repositories/$repository->id/uploads",
+        [
+            'file' => $file,
+        ],
+        [
+            'Accept' => 'application/json',
+        ],
+    )
+        ->assertStatus(201);
+});
+
+it('uploads zip when composer.json is in root but not first entry', function () use ($composerJson, $zipContent): void {
+    user([Permission::UNSCOPED, Permission::PACKAGE_CREATE]);
+
+    $repository = Repository::factory()->state([
+        'sync_mode' => RepositorySyncMode::MANUAL,
+        'name' => 'test/test',
+    ])->create();
+
+    $file = UploadedFile::fake()->createWithContent(
+        name: 'project.zip',
+        content: $zipContent([
+            'src/' => '',
+            'composer.json' => $composerJson,
+        ])
+    );
+
+    post(
+        "/api/repositories/$repository->id/uploads",
+        ['file' => $file],
+        ['Accept' => 'application/json'],
+    )->assertStatus(201);
+});
+
+it('uploads nested zip when composer.json is in top-level directory', function () use ($composerJson, $zipContent): void {
+    user([Permission::UNSCOPED, Permission::PACKAGE_CREATE]);
+
+    $repository = Repository::factory()->state([
+        'sync_mode' => RepositorySyncMode::MANUAL,
+        'name' => 'test/test',
+    ])->create();
+
+    $file = UploadedFile::fake()->createWithContent(
+        name: 'project.zip',
+        content: $zipContent([
+            'project/' => '',
+            'project/src/' => '',
+            'project/composer.json' => $composerJson,
+        ])
+    );
+
+    post(
+        "/api/repositories/$repository->id/uploads",
+        ['file' => $file],
+        ['Accept' => 'application/json'],
+    )->assertStatus(201);
+});
+
+it('rejects zip when composer.json is only nested deeper than top-level directory', function () use ($composerJson, $zipContent): void {
+    user([Permission::UNSCOPED, Permission::PACKAGE_CREATE]);
+
+    $repository = Repository::factory()->state([
+        'sync_mode' => RepositorySyncMode::MANUAL,
+    ])->create();
+
+    $file = UploadedFile::fake()->createWithContent(
+        name: 'project.zip',
+        content: $zipContent([
+            'project/' => '',
+            'project/src/' => '',
+            'project/src/composer.json' => $composerJson,
+        ])
+    );
+
+    post(
+        "/api/repositories/$repository->id/uploads",
+        ['file' => $file],
+        ['Accept' => 'application/json'],
+    )
+        ->assertStatus(422)
+        ->assertExactJson(validation([
+            'file' => ['composer.json not found in archive'],
+        ]));
+});
+
+it('rejects zip when archive has multiple top-level directories without root composer.json', function () use ($composerJson, $zipContent): void {
+    user([Permission::UNSCOPED, Permission::PACKAGE_CREATE]);
+
+    $repository = Repository::factory()->state([
+        'sync_mode' => RepositorySyncMode::MANUAL,
+    ])->create();
+
+    $file = UploadedFile::fake()->createWithContent(
+        name: 'project.zip',
+        content: $zipContent([
+            'project/' => '',
+            'project/composer.json' => $composerJson,
+            'docs/' => '',
+            'docs/readme.md' => '# docs',
+        ])
+    );
+
+    post(
+        "/api/repositories/$repository->id/uploads",
+        ['file' => $file],
+        ['Accept' => 'application/json'],
+    )
+        ->assertStatus(422)
+        ->assertExactJson(validation([
+            'file' => ['composer.json not found in archive'],
+        ]));
+});

--- a/tests/Feature/Repository/StoreTest.php
+++ b/tests/Feature/Repository/StoreTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\Permission;
+use App\Enums\RepositorySyncMode;
 use App\Http\Resources\RepositoryResource;
 use App\Models\Repository;
 use App\Models\User;
@@ -17,6 +18,7 @@ it('stores', function (?User $user, int $status): void {
         'path' => $path = fake()->sentence,
         'description' => fake()->text,
         'public' => fake()->boolean(),
+        'sync_mode' => fake()->randomElement(RepositorySyncMode::cases())->value,
     ])
         ->assertStatus($status);
 

--- a/tests/Feature/Repository/UpdateTest.php
+++ b/tests/Feature/Repository/UpdateTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\Permission;
+use App\Enums\RepositorySyncMode;
 use App\Http\Resources\RepositoryResource;
 use App\Models\Repository;
 use App\Models\User;
@@ -19,6 +20,7 @@ it('updates', function (?User $user, int $status): void {
         'path' => $path = fake()->sentence,
         'description' => fake()->text,
         'public' => fake()->boolean(),
+        'sync_mode' => fake()->randomElement(RepositorySyncMode::cases())->value,
     ];
 
     $response = patchJson("/api/repositories/$repository->id", $attributes)


### PR DESCRIPTION
## Summary

This PR adds a repository-level sync strategy and introduces a manual ZIP ingestion path for packages.

### Technical changes

- Added `RepositorySyncMode` (`source` | `manual`) end-to-end:
  - DB migration: `repositories.sync_mode` (indexed, default `source`)
  - model cast + factory support
  - wired into repository create/update inputs/actions
  - exposed via `RepositoryResource` and frontend API schema

- Added manual upload endpoint:
  - `POST /api/repositories/{repositoryId}/uploads`
  - validates `file` (`mimes:zip`) and optional `version`
  - parses `composer.json`, resolves package name, creates package if missing, creates version from ZIP

- Enforced mode constraints:
  - source-based package import now fails with `422` for `manual` repositories
  - dedicated domain exception with validation payload

- Improved ZIP composer discovery logic:
  - first checks `composer.json` at archive root
  - falls back to single top-level directory
  - ignores `__MACOSX` noise entries

- Frontend behavior updates:
  - repository forms now include `syncMode`
  - repository badges/select labels expose manual mode
  - add-package dialog switches between source import and ZIP upload based on `syncMode`
  - rebuild action disabled when package has no source

- Test coverage:
  - new feature tests for upload flow, validation, auth matrix, and ZIP structure edge cases
  - repository store/update tests include `sync_mode`
  - package store test asserts rejection of source import for manual repos

## Rationale

This decouples package ingestion from VCS/webhook sync and supports controlled/manual artifact publishing while keeping source-sync behavior explicit and guarded.