### PR TITLE
fix: consistent package name if the package name was changed at some …

### DIFF
--- a/app/CreateFromZip.php
+++ b/app/CreateFromZip.php
@@ -36,7 +36,12 @@ class CreateFromZip
         $version ??= $decoded['version'] ?? throw new VersionNotFoundException('no version provided');
         $name = $decoded['name'] ?? throw new NameNotFoundException('no name provided');
 
-        $package->name = $name;
+        $currentOrder = Normalizer::versionOrder($version);
+        $latestOrder = $package->versions()->max('order');
+
+        if ($latestOrder === null || $currentOrder >= $latestOrder) {
+            $package->name = $name;
+        }
 
         $package->description = $decoded['description'] ?? null;
         $package->type = array_key_exists('type', $decoded) && $decoded['type'] !== '' && $decoded['type'] !== null
@@ -60,7 +65,7 @@ class CreateFromZip
 
         $createdVersion->package_id = $package->id;
         $createdVersion->name = $versionName;
-        $createdVersion->order = Normalizer::versionOrder($version);
+        $createdVersion->order = $currentOrder;
         $createdVersion->shasum = $hash;
         $createdVersion->archive_path = $package->repository->archivePath(Str::uuid7()->toString().'.zip');
         $createdVersion->metadata = collect($decoded)->only([

--- a/tests/Feature/Package/CreateFromZipTest.php
+++ b/tests/Feature/Package/CreateFromZipTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\CreateFromZip;
+use App\Models\Package;
+use App\Models\Repository;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Creates a temporary zip file containing a composer.json with the given fields.
+ *
+ * @param  array<string, mixed>  $extra
+ */
+function makeComposerZip(string $name, string $version, array $extra = []): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'packistry_test_').'.zip';
+
+    $zip = new ZipArchive;
+    $zip->open($path, ZipArchive::CREATE);
+    $zip->addFromString('composer.json', json_encode(array_merge([
+        'name' => $name,
+        'version' => $version,
+    ], $extra)));
+    $zip->close();
+
+    return $path;
+}
+
+it('does not overwrite the package name with an older version imported after a newer one', function (): void {
+    Storage::fake();
+
+    $repository = Repository::factory()->create();
+    /** @var Package $package */
+    $package = Package::factory()->for($repository)->create(['name' => 'vendor/initial']);
+
+    $createFromZip = app(CreateFromZip::class);
+
+    $newZip = makeComposerZip('vendor/new-name', '2.0.0', ['replace' => ['vendor/old-name' => '*']]);
+    $oldZip = makeComposerZip('vendor/old-name', '1.0.0');
+
+    try {
+        // Import the newer version first — sets the correct name
+        $createFromZip->create($package, $newZip, '2.0.0');
+        $package->refresh();
+        expect($package->name)->toBe('vendor/new-name');
+
+        // Import the older version second — must NOT overwrite the name
+        $createFromZip->create($package, $oldZip, '1.0.0');
+        $package->refresh();
+        expect($package->name)->toBe('vendor/new-name');
+    } finally {
+        @unlink($newZip);
+        @unlink($oldZip);
+    }
+});
+
+it('updates the package name when a newer version is imported after an older one', function (): void {
+    Storage::fake();
+
+    $repository = Repository::factory()->create();
+    /** @var Package $package */
+    $package = Package::factory()->for($repository)->create(['name' => 'vendor/initial']);
+
+    $createFromZip = app(CreateFromZip::class);
+
+    $oldZip = makeComposerZip('vendor/old-name', '1.0.0');
+    $newZip = makeComposerZip('vendor/new-name', '2.0.0', ['replace' => ['vendor/old-name' => '*']]);
+
+    try {
+        // Import the older version first
+        $createFromZip->create($package, $oldZip, '1.0.0');
+        $package->refresh();
+        expect($package->name)->toBe('vendor/old-name');
+
+        // Import the newer version second — must update to the new name
+        $createFromZip->create($package, $newZip, '2.0.0');
+        $package->refresh();
+        expect($package->name)->toBe('vendor/new-name');
+    } finally {
+        @unlink($oldZip);
+        @unlink($newZip);
+    }
+});


### PR DESCRIPTION
A 3rd party package changed its package name at some point during its history. The package name in packistry is inconsistent because it is dependent on the order of the imported versions. If an older version is imported after the newer versions, the package name is changed to the old name.
This fix should prevent changing the name of the package if the imported version is older.